### PR TITLE
Fix critical bugs and incorrect block references

### DIFF
--- a/src/main/java/anya/pizza/houseki/block/ModBlocks.java
+++ b/src/main/java/anya/pizza/houseki/block/ModBlocks.java
@@ -170,15 +170,15 @@ public class ModBlocks {
     public static final Block LIMESTONE_STAIRS = registerBlock("limestone_stairs",
             properties -> new StairsBlock(ModBlocks.LIMESTONE.getDefaultState(),properties.mapColor(MapColor.OFF_WHITE).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
     public static final Block POLISHED_LIMESTONE_STAIRS = registerBlock("polished_limestone_stairs",
-            properties -> new StairsBlock(ModBlocks.LIMESTONE.getDefaultState(),properties.mapColor(MapColor.OFF_WHITE).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
+            properties -> new StairsBlock(ModBlocks.POLISHED_LIMESTONE.getDefaultState(),properties.mapColor(MapColor.OFF_WHITE).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
     public static final Block LIMESTONE_BRICK_STAIRS = registerBlock("limestone_brick_stairs",
-            properties -> new StairsBlock(ModBlocks.LIMESTONE.getDefaultState(),properties.mapColor(MapColor.OFF_WHITE).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
+            properties -> new StairsBlock(ModBlocks.LIMESTONE_BRICKS.getDefaultState(),properties.mapColor(MapColor.OFF_WHITE).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
     public static final Block SLATE_STAIRS = registerBlock("slate_stairs",
-            properties -> new StairsBlock(ModBlocks.LIMESTONE.getDefaultState(),properties.mapColor(MapColor.DEEPSLATE_GRAY).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
+            properties -> new StairsBlock(ModBlocks.SLATE.getDefaultState(),properties.mapColor(MapColor.DEEPSLATE_GRAY).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
     public static final Block POLISHED_SLATE_STAIRS = registerBlock("polished_slate_stairs",
-            properties -> new StairsBlock(ModBlocks.LIMESTONE.getDefaultState(),properties.mapColor(MapColor.DEEPSLATE_GRAY).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
+            properties -> new StairsBlock(ModBlocks.POLISHED_SLATE.getDefaultState(),properties.mapColor(MapColor.DEEPSLATE_GRAY).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
     public static final Block SLATE_TILE_STAIRS = registerBlock("slate_tile_stairs",
-            properties -> new StairsBlock(ModBlocks.LIMESTONE.getDefaultState(),properties.mapColor(MapColor.DEEPSLATE_GRAY).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
+            properties -> new StairsBlock(ModBlocks.SLATE_TILES.getDefaultState(),properties.mapColor(MapColor.DEEPSLATE_GRAY).instrument(NoteBlockInstrument.BASEDRUM).requiresTool().strength(2, 6)));
 
     //Slabs
     public static final Block LIMESTONE_SLAB = registerBlock("limestone_slab",

--- a/src/main/java/anya/pizza/houseki/item/custom/AdvancedDrillItem.java
+++ b/src/main/java/anya/pizza/houseki/item/custom/AdvancedDrillItem.java
@@ -16,7 +16,7 @@ public class AdvancedDrillItem extends Item {
         super(settings.pickaxe(material, attackDamage, attackSpeed));
     }
 
-    public static List<BlockPos> getBlocksToBeDestroyed(int range, BlockPos intitalBlockPos, ServerPlayerEntity player) {
+    public static List<BlockPos> getBlocksToBeDestroyed(int range, BlockPos initialBlockPos, ServerPlayerEntity player) {
         List<BlockPos> positions = new ArrayList<>();
         HitResult hit = player.raycast(20, 0, false);
         if (hit.getType() == HitResult.Type.BLOCK) {
@@ -24,21 +24,21 @@ public class AdvancedDrillItem extends Item {
             if (blockHit.getSide() == Direction.DOWN || blockHit.getSide() == Direction.UP) {
                 for (int x = -range; x <= range; x++) {
                     for (int y = -range; y <= range; y++) {
-                        positions.add(new BlockPos(intitalBlockPos.getX() + x, intitalBlockPos.getY(), intitalBlockPos.getZ() + y));
+                        positions.add(new BlockPos(initialBlockPos.getX() + x, initialBlockPos.getY(), initialBlockPos.getZ() + y));
                     }
                 }
             }
             if (blockHit.getSide() == Direction.NORTH || blockHit.getSide() == Direction.SOUTH) {
                 for (int x = -range; x <= range; x++) {
                     for (int y = -range; y <= range; y++) {
-                        positions.add(new BlockPos(intitalBlockPos.getX() + x, intitalBlockPos.getY() + y, intitalBlockPos.getZ()));
+                        positions.add(new BlockPos(initialBlockPos.getX() + x, initialBlockPos.getY() + y, initialBlockPos.getZ()));
                     }
                 }
             }
             if (blockHit.getSide() == Direction.EAST || blockHit.getSide() == Direction.WEST) {
                 for (int x = -range; x <= range; x++) {
                     for (int y = -range; y <= range; y++) {
-                        positions.add(new BlockPos(intitalBlockPos.getX(), intitalBlockPos.getY() + y, intitalBlockPos.getZ() + x));
+                        positions.add(new BlockPos(initialBlockPos.getX(), initialBlockPos.getY() + y, initialBlockPos.getZ() + x));
                     }
                 }
             }

--- a/src/main/java/anya/pizza/houseki/item/custom/EnhancedDrillItem.java
+++ b/src/main/java/anya/pizza/houseki/item/custom/EnhancedDrillItem.java
@@ -17,7 +17,7 @@ public class EnhancedDrillItem extends Item {
         super(settings.tool(material, ModTags.Blocks.ENHANCED_DRILL_MINEABLE, attackDamage, attackSpeed, 3));
     }
 
-    public static List<BlockPos> getBlocksToBeDestroyed(int range, BlockPos intitalBlockPos, ServerPlayerEntity player) {
+    public static List<BlockPos> getBlocksToBeDestroyed(int range, BlockPos initialBlockPos, ServerPlayerEntity player) {
         List<BlockPos> positions = new ArrayList<>();
         HitResult hit = player.raycast(20, 0, false);
         if (hit.getType() == HitResult.Type.BLOCK) {
@@ -25,21 +25,21 @@ public class EnhancedDrillItem extends Item {
             if (blockHit.getSide() == Direction.DOWN || blockHit.getSide() == Direction.UP) {
                 for (int x = -range; x <= range; x++) {
                     for (int y = -range; y <= range; y++) {
-                        positions.add(new BlockPos(intitalBlockPos.getX() + x, intitalBlockPos.getY(), intitalBlockPos.getZ() + y));
+                        positions.add(new BlockPos(initialBlockPos.getX() + x, initialBlockPos.getY(), initialBlockPos.getZ() + y));
                     }
                 }
             }
             if (blockHit.getSide() == Direction.NORTH || blockHit.getSide() == Direction.SOUTH) {
                 for (int x = -range; x <= range; x++) {
                     for (int y = -range; y <= range; y++) {
-                        positions.add(new BlockPos(intitalBlockPos.getX() + x, intitalBlockPos.getY() + y, intitalBlockPos.getZ()));
+                        positions.add(new BlockPos(initialBlockPos.getX() + x, initialBlockPos.getY() + y, initialBlockPos.getZ()));
                     }
                 }
             }
             if (blockHit.getSide() == Direction.EAST || blockHit.getSide() == Direction.WEST) {
                 for (int x = -range; x <= range; x++) {
                     for (int y = -range; y <= range; y++) {
-                        positions.add(new BlockPos(intitalBlockPos.getX(), intitalBlockPos.getY() + y, intitalBlockPos.getZ() + x));
+                        positions.add(new BlockPos(initialBlockPos.getX(), initialBlockPos.getY() + y, initialBlockPos.getZ() + x));
                     }
                 }
             }

--- a/src/main/java/anya/pizza/houseki/item/custom/ModArmorItem.java
+++ b/src/main/java/anya/pizza/houseki/item/custom/ModArmorItem.java
@@ -74,13 +74,17 @@ public class ModArmorItem extends Item {
     }
 
     private boolean hasCorrectArmorOn(ArmorMaterial material, PlayerEntity player) {
-        EquippableComponent equippableComponentBoots = player.getEquippedStack(EquipmentSlot.FEET).getItem().getComponents().get(DataComponentTypes.EQUIPPABLE);
-        EquippableComponent equippableComponentLeggings = player.getEquippedStack(EquipmentSlot.LEGS).getItem().getComponents().get(DataComponentTypes.EQUIPPABLE);
-        EquippableComponent equippableComponentBreastplate = player.getEquippedStack(EquipmentSlot.CHEST).getItem().getComponents().get(DataComponentTypes.EQUIPPABLE);
-        EquippableComponent equippableComponentHelmet = player.getEquippedStack(EquipmentSlot.HEAD).getItem().getComponents().get(DataComponentTypes.EQUIPPABLE);
+        EquippableComponent boots = player.getEquippedStack(EquipmentSlot.FEET).getItem().getComponents().get(DataComponentTypes.EQUIPPABLE);
+        EquippableComponent leggings = player.getEquippedStack(EquipmentSlot.LEGS).getItem().getComponents().get(DataComponentTypes.EQUIPPABLE);
+        EquippableComponent chestplate = player.getEquippedStack(EquipmentSlot.CHEST).getItem().getComponents().get(DataComponentTypes.EQUIPPABLE);
+        EquippableComponent helmet = player.getEquippedStack(EquipmentSlot.HEAD).getItem().getComponents().get(DataComponentTypes.EQUIPPABLE);
 
-        return equippableComponentBoots.assetId().get().equals(material.assetId()) && equippableComponentLeggings.assetId().get().equals(material.assetId()) &&
-                equippableComponentBreastplate.assetId().get().equals(material.assetId()) && equippableComponentHelmet.assetId().get().equals(material.assetId());
+        if (boots == null || leggings == null || chestplate == null || helmet == null) return false;
+        if (boots.assetId().isEmpty() || leggings.assetId().isEmpty()
+                || chestplate.assetId().isEmpty() || helmet.assetId().isEmpty()) return false;
+
+        return boots.assetId().get().equals(material.assetId()) && leggings.assetId().get().equals(material.assetId()) &&
+                chestplate.assetId().get().equals(material.assetId()) && helmet.assetId().get().equals(material.assetId());
     }
 
     private boolean hasFullSuitOfArmorOn(PlayerEntity player) {

--- a/src/main/java/anya/pizza/houseki/item/custom/PremiumDrillItem.java
+++ b/src/main/java/anya/pizza/houseki/item/custom/PremiumDrillItem.java
@@ -17,7 +17,7 @@ public class PremiumDrillItem extends Item {
         super(settings.tool(material, ModTags.Blocks.PREMIUM_DRILL_MINEABLE, attackDamage, attackSpeed, 3));
     }
 
-    public static List<BlockPos> getBlocksToBeDestroyed(int range, BlockPos intitalBlockPos, ServerPlayerEntity player) {
+    public static List<BlockPos> getBlocksToBeDestroyed(int range, BlockPos initialBlockPos, ServerPlayerEntity player) {
         List<BlockPos> positions = new ArrayList<>();
         HitResult hit = player.raycast(20, 0, false);
         if (hit.getType() == HitResult.Type.BLOCK) {
@@ -25,21 +25,21 @@ public class PremiumDrillItem extends Item {
             if (blockHit.getSide() == Direction.DOWN || blockHit.getSide() == Direction.UP) {
                 for (int x = -range; x <= range; x++) {
                     for (int y = -range; y <= range; y++) {
-                        positions.add(new BlockPos(intitalBlockPos.getX() + x, intitalBlockPos.getY(), intitalBlockPos.getZ() + y));
+                        positions.add(new BlockPos(initialBlockPos.getX() + x, initialBlockPos.getY(), initialBlockPos.getZ() + y));
                     }
                 }
             }
             if (blockHit.getSide() == Direction.NORTH || blockHit.getSide() == Direction.SOUTH) {
                 for (int x = -range; x <= range; x++) {
                     for (int y = -range; y <= range; y++) {
-                        positions.add(new BlockPos(intitalBlockPos.getX() + x, intitalBlockPos.getY() + y, intitalBlockPos.getZ()));
+                        positions.add(new BlockPos(initialBlockPos.getX() + x, initialBlockPos.getY() + y, initialBlockPos.getZ()));
                     }
                 }
             }
             if (blockHit.getSide() == Direction.EAST || blockHit.getSide() == Direction.WEST) {
                 for (int x = -range; x <= range; x++) {
                     for (int y = -range; y <= range; y++) {
-                        positions.add(new BlockPos(intitalBlockPos.getX(), intitalBlockPos.getY() + y, intitalBlockPos.getZ() + x));
+                        positions.add(new BlockPos(initialBlockPos.getX(), initialBlockPos.getY() + y, initialBlockPos.getZ() + x));
                     }
                 }
             }

--- a/src/main/java/anya/pizza/houseki/util/ADUsageEvent.java
+++ b/src/main/java/anya/pizza/houseki/util/ADUsageEvent.java
@@ -27,7 +27,7 @@ public class ADUsageEvent implements PlayerBlockBreakEvents.Before{
                 return true;
             }
             for (BlockPos position : AdvancedDrillItem.getBlocksToBeDestroyed(2, pos, serverPlayer)) { //5x5
-                if (pos == position || !ad.isCorrectForDrops(mainHandItem, world.getBlockState(position))) {
+                if (pos.equals(position) || !ad.isCorrectForDrops(mainHandItem, world.getBlockState(position))) {
                     continue;
                 }
                 HARVESTED_BLOCKS.add(position);

--- a/src/main/java/anya/pizza/houseki/util/EDUsageEvent.java
+++ b/src/main/java/anya/pizza/houseki/util/EDUsageEvent.java
@@ -27,7 +27,7 @@ public class EDUsageEvent implements PlayerBlockBreakEvents.Before{
                 return true;
             }
             for (BlockPos position : EnhancedDrillItem.getBlocksToBeDestroyed(1, pos, serverPlayer)) { //3x3
-                if (pos == position || !ed.isCorrectForDrops(mainHandItem, world.getBlockState(position))) {
+                if (pos.equals(position) || !ed.isCorrectForDrops(mainHandItem, world.getBlockState(position))) {
                     continue;
                 }
                 HARVESTED_BLOCKS.add(position);

--- a/src/main/java/anya/pizza/houseki/util/ModLootTableModifiers.java
+++ b/src/main/java/anya/pizza/houseki/util/ModLootTableModifiers.java
@@ -36,7 +36,7 @@ public class ModLootTableModifiers {
     private static final Identifier TRIAL_REWARD_RARE_ID = Identifier.of("minecraft", "chests/trial_chambers/reward_rare");
     private static final Identifier TRIAL_REWARD_OMINOUS_RARE_ID = Identifier.of("minecraft", "chests/trial_chambers/reward_ominous_rare");
     private static final Identifier TRIAL_REWARD_UNIQUE_ID = Identifier.of("minecraft", "chests/trial_chambers/reward_unique");
-    private static final Identifier TRIAL_REWARD_OMINOUS_UNIQUE_ID = Identifier.of("minecraft", "chests/trial_chambers/reward_unique");
+    private static final Identifier TRIAL_REWARD_OMINOUS_UNIQUE_ID = Identifier.of("minecraft", "chests/trial_chambers/reward_ominous_unique");
     private static final Identifier VILLAGE_MASON_ID = Identifier.of("minecraft", "chests/village/village_mason");
     private static final Identifier VILLAGE_TOOLSMITH_ID = Identifier.of("minecraft", "chests/village/village_toolsmith");
     private static final Identifier VILLAGE_WEAPONSMITH_ID = Identifier.of("minecraft", "chests/village/village_weaponsmith");

--- a/src/main/java/anya/pizza/houseki/util/PDUsageEvent.java
+++ b/src/main/java/anya/pizza/houseki/util/PDUsageEvent.java
@@ -27,7 +27,7 @@ public class PDUsageEvent implements PlayerBlockBreakEvents.Before{
                 return true;
             }
             for (BlockPos position : PremiumDrillItem.getBlocksToBeDestroyed(2, pos, serverPlayer)) { //5x5
-                if (pos == position || !pd.isCorrectForDrops(mainHandItem, world.getBlockState(position))) {
+                if (pos.equals(position) || !pd.isCorrectForDrops(mainHandItem, world.getBlockState(position))) {
                     continue;
                 }
                 HARVESTED_BLOCKS.add(position);


### PR DESCRIPTION
- Fix BlockPos == comparison to .equals() in drill events
- Fix NPE in ModArmorItem armor check (null/empty guard)
- Fix stairs blocks referencing wrong base materials
- Fix duplicate trial chamber loot table identifier
- Fix intitalBlockPos typo in drill items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Fixed BlockPos comparisons in drill events (ADUsageEvent, EDUsageEvent, PDUsageEvent) by replacing reference equality (`==`) with value-based equality (`.equals()`)
- Corrected base material references for stairs blocks: POLISHED_LIMESTONE_STAIRS, LIMESTONE_BRICK_STAIRS, SLATE_STAIRS, POLISHED_SLATE_STAIRS, and SLATE_TILE_STAIRS now reference correct base blocks
- Added null/empty guards to ModArmorItem armor check to prevent NullPointerException when EquippableComponent is missing
- Fixed duplicate trial chamber loot table identifier in ModLootTableModifiers to reference correct ominous unique loot table
- Corrected typo `intitalBlockPos` → `initialBlockPos` in AdvancedDrillItem, EnhancedDrillItem, and PremiumDrillItem

## Changes by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| shaedy180 | 30 | 26 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->