### PR TITLE
Fix duplicate output slot and improve armor casting functionality

### DIFF
--- a/src/main/java/anya/pizza/houseki/block/entity/custom/FoundryBlockEntity.java
+++ b/src/main/java/anya/pizza/houseki/block/entity/custom/FoundryBlockEntity.java
@@ -466,21 +466,33 @@ public class FoundryBlockEntity extends BlockEntity implements ExtendedScreenHan
      * @return the resulting ItemStack for the cast (a pickaxe head) or `ItemStack.EMPTY` if no match
      */
     private ItemStack getResultFromCast(ItemStack cast) {
-        // Map cast + active metal type to the correct output head
+        // Map cast + active metal type to the correct output
         if (activeMetalType == METAL_STEEL) {
+            // Tool heads
             if (cast.isOf(ModItems.PICKAXE_HEAD_CAST)) return new ItemStack(ModItems.CS_PICKAXE_HEAD);
             if (cast.isOf(ModItems.AXE_HEAD_CAST)) return new ItemStack(ModItems.CS_AXE_HEAD);
             if (cast.isOf(ModItems.SHOVEL_HEAD_CAST)) return new ItemStack(ModItems.CS_SHOVEL_HEAD);
             if (cast.isOf(ModItems.SWORD_HEAD_CAST)) return new ItemStack(ModItems.CS_SWORD_HEAD);
             if (cast.isOf(ModItems.HOE_HEAD_CAST)) return new ItemStack(ModItems.CS_HOE_HEAD);
             if (cast.isOf(ModItems.SPEAR_HEAD_CAST)) return new ItemStack(ModItems.CS_SPEAR_HEAD);
+            // Armor
+            if (cast.isOf(ModItems.HELMET_CAST)) return new ItemStack(ModItems.CAST_STEEL_HELMET);
+            if (cast.isOf(ModItems.CHESTPLATE_CAST)) return new ItemStack(ModItems.CAST_STEEL_CHESTPLATE);
+            if (cast.isOf(ModItems.LEGGINGS_CAST)) return new ItemStack(ModItems.CAST_STEEL_LEGGINGS);
+            if (cast.isOf(ModItems.BOOTS_CAST)) return new ItemStack(ModItems.CAST_STEEL_BOOTS);
         } else if (activeMetalType == METAL_METEORIC_IRON) {
+            // Tool heads
             if (cast.isOf(ModItems.PICKAXE_HEAD_CAST)) return new ItemStack(ModItems.MI_PICKAXE_HEAD);
             if (cast.isOf(ModItems.AXE_HEAD_CAST)) return new ItemStack(ModItems.MI_AXE_HEAD);
             if (cast.isOf(ModItems.SHOVEL_HEAD_CAST)) return new ItemStack(ModItems.MI_SHOVEL_HEAD);
             if (cast.isOf(ModItems.SWORD_HEAD_CAST)) return new ItemStack(ModItems.MI_SWORD_HEAD);
             if (cast.isOf(ModItems.HOE_HEAD_CAST)) return new ItemStack(ModItems.MI_HOE_HEAD);
             if (cast.isOf(ModItems.SPEAR_HEAD_CAST)) return new ItemStack(ModItems.MI_SPEAR_HEAD);
+            // Armor
+            if (cast.isOf(ModItems.HELMET_CAST)) return new ItemStack(ModItems.METEORIC_IRON_HELMET);
+            if (cast.isOf(ModItems.CHESTPLATE_CAST)) return new ItemStack(ModItems.METEORIC_IRON_CHESTPLATE);
+            if (cast.isOf(ModItems.LEGGINGS_CAST)) return new ItemStack(ModItems.METEORIC_IRON_LEGGINGS);
+            if (cast.isOf(ModItems.BOOTS_CAST)) return new ItemStack(ModItems.METEORIC_IRON_BOOTS);
         }
         return ItemStack.EMPTY;
     }

--- a/src/main/java/anya/pizza/houseki/screen/custom/FoundryScreenHandler.java
+++ b/src/main/java/anya/pizza/houseki/screen/custom/FoundryScreenHandler.java
@@ -67,18 +67,6 @@ public class FoundryScreenHandler extends ScreenHandler {
         });
         this.addSlot(new Slot(inventory, 3, 135, 53) { //Output Slot
             /**
-             * Prevents manual insertion into this output slot.
-             *
-             * @param player the player attempting to take items from the slot
-             * @return `true` if cooling is not active and the player may take items, `false` otherwise
-             */
-            @Override
-            public boolean canTakeItems(PlayerEntity player) {
-                return propertyDelegate.get(9) == 0;
-            }
-        });
-        this.addSlot(new Slot(inventory, 3, 135, 53) { //Output Slot
-            /**
              * Prevents any ItemStack from being inserted into this slot.
              *
              * @param stack the ItemStack being offered for insertion (ignored)

--- a/src/main/java/anya/pizza/houseki/screen/custom/FoundryScreenHandler.java
+++ b/src/main/java/anya/pizza/houseki/screen/custom/FoundryScreenHandler.java
@@ -150,9 +150,12 @@ public class FoundryScreenHandler extends ScreenHandler {
                 slot.onQuickTransfer(originalStack, itemStack);
             } else {
                 // All cast items go to the cast slot
+                // All cast items (tool heads + armor) go to the cast slot
                 if (originalStack.isOf(ModItems.PICKAXE_HEAD_CAST) || originalStack.isOf(ModItems.AXE_HEAD_CAST)
                         || originalStack.isOf(ModItems.SHOVEL_HEAD_CAST) || originalStack.isOf(ModItems.SWORD_HEAD_CAST)
-                        || originalStack.isOf(ModItems.HOE_HEAD_CAST) || originalStack.isOf(ModItems.SPEAR_HEAD_CAST)) {
+                        || originalStack.isOf(ModItems.HOE_HEAD_CAST) || originalStack.isOf(ModItems.SPEAR_HEAD_CAST)
+                        || originalStack.isOf(ModItems.HELMET_CAST) || originalStack.isOf(ModItems.CHESTPLATE_CAST)
+                        || originalStack.isOf(ModItems.LEGGINGS_CAST) || originalStack.isOf(ModItems.BOOTS_CAST)) {
                     if (!this.insertItem(originalStack, 2, 3, false)) {
                         return ItemStack.EMPTY;
                     }


### PR DESCRIPTION
merge broke something after all - fixed now!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Fixed duplicate output slot in foundry screen handler that was introduced by a merge
- Added armor cast support to foundry functionality (helmet, chestplate, leggings, and boots casts)
- Improved shift-click behavior to properly handle all cast types including armor casts
- Fixed result mapping for armor casts for both steel and meteoric iron metal types

## Contributor Statistics

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| shaedy180 | 17 | 14 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->