### PR TITLE
1.21.11-meteorss

### DIFF
--- a/src/main/generated/.cache/28e4dcfa88825aaf104b230f37e8789004c8a7c0
+++ b/src/main/generated/.cache/28e4dcfa88825aaf104b230f37e8789004c8a7c0
@@ -1,6 +1,6 @@
 // 1.21.11	-999999999-01-01T00:00:00	Houseki/Tags for minecraft:block
 23caf7f61e4b2f6fa59b168a7ee49539eb44acf1 data/houseki/tags/block/enhanced_mineable.json
-2da583f721f259c6889e51658f404960df9ec3ab data/houseki/tags/block/meteor_wont_replace.json
+1a39479598db3fcb1011704aa283ce843d5b4192 data/houseki/tags/block/meteor_wont_replace.json
 80ad3ac92e1280a2f60b25a83d2a16751740cc33 data/houseki/tags/block/premium_mineable.json
 3a872b346c761360db3b94468363a00d2bffd9e7 data/minecraft/tags/block/beacon_base_blocks.json
 0f1595e54291f56a27bc1017154402fbafdc332a data/minecraft/tags/block/dragon_immune.json

--- a/src/main/generated/data/houseki/tags/block/meteor_wont_replace.json
+++ b/src/main/generated/data/houseki/tags/block/meteor_wont_replace.json
@@ -1,6 +1,5 @@
 {
   "values": [
-    "#minecraft:base_stone_overworld",
     "#minecraft:coal_ores",
     "#minecraft:iron_ores",
     "#minecraft:gold_ores",

--- a/src/main/java/anya/pizza/houseki/datagen/ModBlockTagProvider.java
+++ b/src/main/java/anya/pizza/houseki/datagen/ModBlockTagProvider.java
@@ -181,11 +181,9 @@ public class ModBlockTagProvider extends FabricTagProvider.BlockTagProvider {
                 .addOptionalTag(BlockTags.SHOVEL_MINEABLE);
 
         valueLookupBuilder(ModTags.Blocks.METEOR_WONT_REPLACE)
-                .forceAddTag(BlockTags.BASE_STONE_OVERWORLD)
                 .forceAddTag(BlockTags.COAL_ORES)
                 .forceAddTag(BlockTags.IRON_ORES)
                 .forceAddTag(BlockTags.GOLD_ORES)
-                .forceAddTag(BlockTags.TERRACOTTA)
                 .add(ModBlocks.PLATINUM_ORE)
                 .add(ModBlocks.DEEPSLATE_PLATINUM_ORE)
                 .add(Blocks.COBBLESTONE)

--- a/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
@@ -2,6 +2,7 @@ package anya.pizza.houseki.world.structure;
 
 import anya.pizza.houseki.block.ModBlocks;
 import anya.pizza.houseki.util.ModTags;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.nbt.NbtCompound;
@@ -30,10 +31,10 @@ import net.minecraft.world.gen.chunk.ChunkGenerator;
  */
 public class MeteoriteStructurePiece extends StructurePiece {
     // Size range for the meteorite sphere (in blocks). Diameter will be 2x this.
-    public static final int MIN_RADIUS = 20;
-    public static final int MAX_RADIUS = 60;
+    public static final int MIN_RADIUS = 5;
+    public static final int MAX_RADIUS = 10;
     // How much wider the crater is than the meteorite itself
-    private static final int CRATER_EXTRA = 6;
+    private static final int CRATER_EXTRA = 25;
     // How far above the surface we clear blocks (to remove tall trees)
     private static final int TREE_CLEAR_HEIGHT = 60;
 
@@ -92,8 +93,11 @@ public class MeteoriteStructurePiece extends StructurePiece {
     // deepest at the center, gradually rising to surface level at the edges.
     private int getCraterFloorY(double horizDist, int craterRadius) {
         if (horizDist > craterRadius) return surfaceY;
-        double depthFraction = 1.0 - (horizDist / craterRadius);
-        int localDepth = (int) (craterDepth * depthFraction * depthFraction);
+        //double depthFraction = 1.0 - (horizDist / craterRadius);
+        double distanceRatio = horizDist / craterRadius;
+        double bowlCurve = Math.sqrt(1.0 - (distanceRatio * distanceRatio));
+        //int localDepth = (int) (craterDepth * depthFraction * depthFraction);
+        int localDepth = (int) (craterDepth * bowlCurve);
         return surfaceY - localDepth;
     }
 
@@ -115,7 +119,8 @@ public class MeteoriteStructurePiece extends StructurePiece {
         // Deterministic random from stored seed - critical for cross-chunk consistency
         Random random = Random.create(this.seed);
         int craterRadius = meteorRadius + CRATER_EXTRA;
-        int meteorCenterY = surfaceY - craterDepth;
+        int settleAmount = 5;
+        int meteorCenterY = (surfaceY - craterDepth) + meteorRadius - settleAmount;
         BlockPos meteorCenter = new BlockPos(centerX, meteorCenterY, centerZ);
 
         // Bail out if the center is in water or lava - meteorites in oceans look bad
@@ -131,7 +136,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
         for (int dx = -craterRadius - 2; dx <= craterRadius + 2; dx++) {
             for (int dz = -craterRadius - 2; dz <= craterRadius + 2; dz++) {
                 double horizDist = Math.sqrt(dx * dx + dz * dz);
-                if (horizDist > craterRadius + 2) continue;
+                if (horizDist > craterRadius + 5) continue;
 
                 int bx = centerX + dx;
                 int bz = centerZ + dz;
@@ -161,7 +166,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
                         if (existing.isOf(Blocks.BEDROCK)) continue;
                         if (!existing.isAir()) {
                             // Replace dirt, sand, grass, etc. with crater material
-                            if (!isStoneType(existing)) {
+                            if (!meteorWontReplace(existing)) {
                                 world.setBlockState(floorPos, getCraterLiner(random), 2);
                             }
                         }
@@ -199,7 +204,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
 
                     // Check if this block is exposed (has air neighbor)
                     if (isExposedToAir(world, pos, chunkBox)) {
-                        if (!isStoneType(state)) {
+                        if (!meteorWontReplace(state)) {
                             world.setBlockState(pos, getCraterLiner(random), 2);
                         }
                     }
@@ -262,9 +267,9 @@ public class MeteoriteStructurePiece extends StructurePiece {
                 double horizDist = Math.sqrt(dx * dx + dz * dz);
                 if (horizDist < craterRadius - 2.5 || horizDist > craterRadius + 2) continue;
 
-                BlockState rimBlock = getShellBlock(random);
+                BlockState rimBlock = getEjectaRim(random);
                 int rimRoll = random.nextInt(3);
-                BlockState raisedBlock = getShellBlock(random);
+                BlockState raisedBlock = getEjectaRim(random);
 
                 int bx = centerX + dx;
                 int bz = centerZ + dz;
@@ -291,8 +296,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
         }
     }
 
-    // Returns true for natural stone variants that don't need to be replaced in crater walls/floor.
-    private boolean isStoneType(BlockState state) {
+    private boolean meteorWontReplace(BlockState state) {
         return state.isIn(ModTags.Blocks.METEOR_WONT_REPLACE);
     }
 
@@ -315,25 +319,35 @@ public class MeteoriteStructurePiece extends StructurePiece {
         return false;
     }
 
-    // Weighted random palette for crater floors and walls: 50% stone, 20% cobble, 20% gravel, 10% cobbled deepslate
+    // Weighted random palette for crater floors and walls
     private BlockState getCraterLiner(Random random) {
         int roll = random.nextInt(10);
-        if (roll < 5) return Blocks.STONE.getDefaultState();
+        if (roll < 6) return Blocks.STONE.getDefaultState();
         if (roll < 7) return Blocks.COBBLESTONE.getDefaultState();
-        if (roll < 9) return Blocks.GRAVEL.getDefaultState();
+        if (roll < 8) return Blocks.MAGMA_BLOCK.getDefaultState();
+        if (roll < 9) return Blocks.COBBLED_DEEPSLATE.getDefaultState();
         if (roll < 10) return Blocks.COAL_BLOCK.getDefaultState();
-        return Blocks.COBBLED_DEEPSLATE.getDefaultState();
+        return Blocks.GRAVEL.getDefaultState();
     }
 
-    // Weighted random palette for the meteorite shell and rim: 40% stone, 20% cobble, 20% gravel, 20% deepslate
+    // Weighted random palette for the meteorite shell
     private BlockState getShellBlock(Random random) {
         int roll = random.nextInt(10);
-        if (roll < 3) return Blocks.REDSTONE_BLOCK.getDefaultState();
-        //if (roll < 3) return Blocks.AIR.getDefaultState();
-        //if (roll < 4) return Blocks.STONE.getDefaultState();
-        //if (roll < 6) return Blocks.COBBLESTONE.getDefaultState();
-        //if (roll < 8) return Blocks.GRAVEL.getDefaultState();
-        //return Blocks.DEEPSLATE.getDefaultState();
-        return Blocks.IRON_BLOCK.getDefaultState();
+        if (roll < 4) return Blocks.COBBLED_DEEPSLATE.getDefaultState();
+        if (roll < 6) return Blocks.COBBLESTONE.getDefaultState();
+        if (roll < 8) return Blocks.MAGMA_BLOCK.getDefaultState();
+        if (roll < 10) return Blocks.COAL_BLOCK.getDefaultState();
+        return Blocks.OBSIDIAN.getDefaultState();
+    }
+
+    private BlockState getEjectaRim(Random random) {
+        int roll = random.nextInt(10);
+        if (roll < 3) return Blocks.COBBLED_DEEPSLATE.getDefaultState();
+        if (roll < 4) return Blocks.GRAVEL.getDefaultState();
+        if (roll < 5) return Blocks.DIRT.getDefaultState();
+        if (roll < 6) return Blocks.COBBLESTONE.getDefaultState();
+        if (roll < 8) return Blocks.STONE.getDefaultState();
+        if (roll < 10) return Blocks.COAL_BLOCK.getDefaultState();
+        return Blocks.OBSIDIAN.getDefaultState();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Reduced meteorite structure footprint by adjusting minimum radius from 20–60 blocks to 5–10 blocks
- Expanded crater widening to 25 blocks (from 6) for more dramatic impact effect
- Introduced vertical settlement offset for meteorites to achieve more realistic positioning
- Changed crater floor profile from squared bowl to circular/square-root bowl curve for smoother transitions
- Refactored block replacement logic to use tag-based predicates instead of stone-variant checks
- Updated crater liner material palette with increased magma and cobbled deepslate weights
- Completely redesigned meteorite shell palette (now cobbled deepslate, cobblestone, magma, coal, and obsidian)
- Added new ejecta rim material palette for crater rim generation
- Removed forced tag inclusions (BASE_STONE_OVERWORLD and TERRACOTTA) from METEOR_WONT_REPLACE configuration

## Author Contributions

| Author | Lines Added | Lines Removed |
|--------|------------|---------------|
| AnyaPizza | 40 | 28 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->