### PR TITLE
26.1 meteor variants, improved generation and block / structure detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,8 @@
 # These are Windows script files and should use crlf
 *.bat           text eol=crlf
 
+# Normalize generated and resource JSON files to LF so Windows checkouts
+# do not produce hundreds of line-ending-only dirty files.
+*.json          text eol=lf
+*.java          text eol=lf
+

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ replay_*.log
 
 # accidental conflict copies
 *Name clash*
+
+# decompiled Minecraft class files (used for API inspection, not project source)
+net/

--- a/src/main/generated/data/houseki/worldgen/structure/meteorite.json
+++ b/src/main/generated/data/houseki/worldgen/structure/meteorite.json
@@ -2,5 +2,5 @@
   "type": "houseki:meteorite",
   "biomes": "#minecraft:is_overworld",
   "spawn_overrides": {},
-  "step": "surface_structures"
+  "step": "top_layer_modification"
 }

--- a/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructure.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructure.java
@@ -2,6 +2,11 @@ package anya.pizza.houseki.world.structure;
 
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.tags.BiomeTags;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.level.biome.Climate;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.WorldgenRandom;
 import net.minecraft.world.level.levelgen.structure.Structure;
@@ -53,9 +58,25 @@ public class MeteoriteStructure extends Structure {
         // Generate a seed for the piece so it can produce deterministic results across chunk passes
         long pieceSeed = random.nextLong();
 
+        // Determine biome variant now, while the full biome source is accessible.
+        // During postProcess only nearby chunks are available, so sampling the biome
+        // at the meteor center from there would crash for large structures.
+        Climate.Sampler sampler = context.randomState().sampler();
+        Holder<Biome> biome = context.biomeSource().getNoiseBiome(
+                x >> 2, surfaceY >> 2, z >> 2, sampler);
+
+        // Reject ocean and river biomes outright. Without this, the structure
+        // is registered (visible to /locate) but postProcess skips it silently,
+        // creating ghost entries that players can never find.
+        if (biome.is(BiomeTags.IS_OCEAN) || biome.is(BiomeTags.IS_RIVER)) {
+            return Optional.empty();
+        }
+
+        int biomeVariantId = MeteoriteStructurePiece.resolveBiomeVariantId(biome);
+
         return Optional.of(new GenerationStub(pos, collector -> {
             collector.addPiece(new MeteoriteStructurePiece(
-                    x, surfaceY, z, radius, craterDepth, pieceSeed));
+                    x, surfaceY, z, radius, craterDepth, pieceSeed, biomeVariantId));
         }));
     }
 

--- a/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructure.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructure.java
@@ -75,16 +75,25 @@ public class MeteoriteStructure extends Structure {
         }
 
         // Check terrain height variance and water presence around the impact site.
-        // Sample center + 8 perimeter points at half the crater radius.
+        // Sample at three distances: center, half crater radius, and full clearing
+        // radius. Using only half-radius missed water bodies near the crater edge,
+        // causing hard vertical cutoffs where the bowl meets the water.
         // Reject if:
         //   - any point's height differs by >8 blocks from center (steep terrain)
         //   - any point has water (WORLD_SURFACE_WG != OCEAN_FLOOR_WG)
-        // This catches inland lakes in any biome that biome tags can't detect.
         int craterRadius = radius + 25; // same as CRATER_EXTRA in MeteoriteStructurePiece
-        int sampleDist = craterRadius / 2;
-        int[][] offsets = {{0, 0},
-                {sampleDist, 0}, {-sampleDist, 0}, {0, sampleDist}, {0, -sampleDist},
-                {sampleDist, sampleDist}, {sampleDist, -sampleDist}, {-sampleDist, sampleDist}, {-sampleDist, -sampleDist}};
+        int vegClearRadius = craterRadius + 12;
+        int innerDist = craterRadius / 2;
+        int outerDist = vegClearRadius;
+        int[][] offsets = {
+                {0, 0},
+                // Inner ring at half crater radius
+                {innerDist, 0}, {-innerDist, 0}, {0, innerDist}, {0, -innerDist},
+                {innerDist, innerDist}, {innerDist, -innerDist}, {-innerDist, innerDist}, {-innerDist, -innerDist},
+                // Outer ring at full vegetation clearing radius
+                {outerDist, 0}, {-outerDist, 0}, {0, outerDist}, {0, -outerDist},
+                {outerDist, outerDist}, {outerDist, -outerDist}, {-outerDist, outerDist}, {-outerDist, -outerDist}
+        };
         for (int[] off : offsets) {
             int sx = x + off[0];
             int sz = z + off[1];

--- a/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructure.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructure.java
@@ -65,11 +65,42 @@ public class MeteoriteStructure extends Structure {
         Holder<Biome> biome = context.biomeSource().getNoiseBiome(
                 x >> 2, surfaceY >> 2, z >> 2, sampler);
 
-        // Reject ocean and river biomes outright. Without this, the structure
-        // is registered (visible to /locate) but postProcess skips it silently,
-        // creating ghost entries that players can never find.
-        if (biome.is(BiomeTags.IS_OCEAN) || biome.is(BiomeTags.IS_RIVER)) {
+        // Reject ocean, river, beach and shore biomes outright. Without this,
+        // the structure is registered (visible to /locate) but postProcess skips it
+        // silently, creating ghost entries that players can never find.
+        if (biome.is(BiomeTags.IS_OCEAN) || biome.is(BiomeTags.IS_RIVER)
+                || biome.is(BiomeTags.IS_BEACH)
+                || biome.is(Biomes.STONY_SHORE)) {
             return Optional.empty();
+        }
+
+        // Check terrain height variance and water presence around the impact site.
+        // Sample center + 8 perimeter points at half the crater radius.
+        // Reject if:
+        //   - any point's height differs by >8 blocks from center (steep terrain)
+        //   - any point has water (WORLD_SURFACE_WG != OCEAN_FLOOR_WG)
+        // This catches inland lakes in any biome that biome tags can't detect.
+        int craterRadius = radius + 25; // same as CRATER_EXTRA in MeteoriteStructurePiece
+        int sampleDist = craterRadius / 2;
+        int[][] offsets = {{0, 0},
+                {sampleDist, 0}, {-sampleDist, 0}, {0, sampleDist}, {0, -sampleDist},
+                {sampleDist, sampleDist}, {sampleDist, -sampleDist}, {-sampleDist, sampleDist}, {-sampleDist, -sampleDist}};
+        for (int[] off : offsets) {
+            int sx = x + off[0];
+            int sz = z + off[1];
+            int sampleSurface = context.chunkGenerator().getBaseHeight(
+                    sx, sz, Heightmap.Types.WORLD_SURFACE_WG,
+                    context.heightAccessor(), context.randomState());
+            int sampleFloor = context.chunkGenerator().getBaseHeight(
+                    sx, sz, Heightmap.Types.OCEAN_FLOOR_WG,
+                    context.heightAccessor(), context.randomState());
+            // Water detected: surface is above the ocean floor
+            if (sampleSurface - sampleFloor > 1) {
+                return Optional.empty();
+            }
+            if (Math.abs(sampleSurface - surfaceY) > 8) {
+                return Optional.empty();
+            }
         }
 
         int biomeVariantId = MeteoriteStructurePiece.resolveBiomeVariantId(biome);

--- a/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
@@ -56,10 +56,12 @@ public class MeteoriteStructurePiece extends StructurePiece {
     private final int meteorRadius; // radius of the meteorite sphere (7-11)
     private final int craterDepth;  // how deep the crater goes below surfaceY
     private final long seed;        // deterministic seed for reproducible random across chunk passes
+    private final int biomeVariantId; // ordinal of BiomeVariant, determined at structure placement time
 
     // Primary constructor, used when the structure is first created during worldgen
     public MeteoriteStructurePiece(int centerX, int surfaceY, int centerZ,
-                                   int meteorRadius, int craterDepth, long seed) {
+                                   int meteorRadius, int craterDepth, long seed,
+                                   int biomeVariantId) {
         super(ModStructures.METEORITE_PIECE_TYPE, 0,
                 makeBounds(centerX, surfaceY, centerZ, meteorRadius, craterDepth));
         this.centerX = centerX;
@@ -68,6 +70,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
         this.meteorRadius = meteorRadius;
         this.craterDepth = craterDepth;
         this.seed = seed;
+        this.biomeVariantId = biomeVariantId;
     }
 
     // NBT constructor, used when loading from a saved game. orElse() provides fallback defaults.
@@ -79,6 +82,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
         this.meteorRadius = data.getInt("mr").orElse(7);
         this.craterDepth = data.getInt("cd").orElse(10);
         this.seed = data.getLong("seed").orElse(0L);
+        this.biomeVariantId = data.getInt("bv").orElse(0);
     }
 
     // Computes the bounding box that fully encloses the structure.
@@ -98,6 +102,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
         data.putInt("mr", meteorRadius);
         data.putInt("cd", craterDepth);
         data.putLong("seed", seed);
+        data.putInt("bv", biomeVariantId);
     }
 
     // Returns the Y of the crater floor at a given horizontal distance from center.
@@ -112,24 +117,29 @@ public class MeteoriteStructurePiece extends StructurePiece {
     }
 
     /**
-     * Determines the visual variant based on the biome at the meteor center.
-     * Only affects crater lining, meteorite shell, and ejecta rim blocks.
-     * Core blocks (METEORIC_IRON) and debris are unchanged.
+     * Maps a biome holder to its variant ordinal. Called from MeteoriteStructure during
+     * findGenerationPoint, where the full biome source is safely accessible.
      */
-    private BiomeVariant determineBiomeVariant(WorldGenLevel level) {
-        Holder<Biome> biome = level.getBiome(new BlockPos(centerX, surfaceY, centerZ));
-
+    public static int resolveBiomeVariantId(Holder<Biome> biome) {
         if (biome.is(Biomes.DESERT)) {
-            return BiomeVariant.DESERT;
+            return BiomeVariant.DESERT.ordinal();
         }
         if (biome.is(Biomes.MANGROVE_SWAMP) || biome.is(Biomes.SWAMP)) {
-            return BiomeVariant.MANGROVE;
+            return BiomeVariant.MANGROVE.ordinal();
         }
         if (biome.is(Biomes.SNOWY_PLAINS) || biome.is(Biomes.SNOWY_TAIGA)
                 || biome.is(Biomes.SNOWY_BEACH) || biome.is(Biomes.SNOWY_SLOPES)
                 || biome.is(Biomes.FROZEN_PEAKS) || biome.is(Biomes.ICE_SPIKES)
                 || biome.is(Biomes.GROVE)) {
-            return BiomeVariant.SNOWY;
+            return BiomeVariant.SNOWY.ordinal();
+        }
+        return BiomeVariant.DEFAULT.ordinal();
+    }
+
+    private BiomeVariant getVariant() {
+        BiomeVariant[] values = BiomeVariant.values();
+        if (biomeVariantId >= 0 && biomeVariantId < values.length) {
+            return values[biomeVariantId];
         }
         return BiomeVariant.DEFAULT;
     }
@@ -155,13 +165,18 @@ public class MeteoriteStructurePiece extends StructurePiece {
         int settleAmount = 5;
         int meteorCenterY = (surfaceY - craterDepth) + meteorRadius - settleAmount;
         BlockPos meteorCenter = new BlockPos(centerX, meteorCenterY, centerZ);
-        BiomeVariant variant = determineBiomeVariant(level);
+        BiomeVariant variant = getVariant();
 
-        // Bail out if the center is in water or lava - meteorites in oceans look bad
+        // Bail out on lava for all variants. Bail out on water only for DEFAULT
+        // and DESERT variants. Swamp/Mangrove and Snowy biomes commonly have water
+        // surfaces and are allowed to generate with water present.
         BlockPos surfacePos = new BlockPos(centerX, surfaceY - 1, centerZ);
         BlockState surfaceState = level.getBlockState(surfacePos);
+        if (surfaceState.getFluidState().is(FluidTags.LAVA)) {
+            return;
+        }
         if (surfaceState.getFluidState().is(FluidTags.WATER)
-                || surfaceState.getFluidState().is(FluidTags.LAVA)) {
+                && variant != BiomeVariant.MANGROVE && variant != BiomeVariant.SNOWY) {
             return;
         }
 
@@ -267,6 +282,39 @@ public class MeteoriteStructurePiece extends StructurePiece {
                         if (!meteorWontReplace(state)) {
                             level.setBlock(pos, getCraterLiner(random, variant), 2);
                         }
+                    }
+                }
+            }
+        }
+
+        // Phase 2.5: Seal caves and ravines beneath the crater.
+        // Carvers (caves, ravines) run before structures and may have opened gaps
+        // below the crater floor that would be visible from inside. Scan downward
+        // from just below the 2-block liner and fill any air or fluid pockets until
+        // we hit a thick enough stretch of solid material.
+        int sealDepth = craterDepth + meteorRadius;
+        for (int dx = -craterRadius - 1; dx <= craterRadius + 1; dx++) {
+            for (int dz = -craterRadius - 1; dz <= craterRadius + 1; dz++) {
+                double horizDist = Math.sqrt(dx * dx + dz * dz);
+                if (horizDist > craterRadius + 1) continue;
+
+                int bx = centerX + dx;
+                int bz = centerZ + dz;
+                int craterFloorY = getCraterFloorY(horizDist, craterRadius);
+
+                int solidStreak = 0;
+                for (int y = craterFloorY - 3; y >= craterFloorY - sealDepth; y--) {
+                    BlockPos pos = new BlockPos(bx, y, bz);
+                    if (!chunkBox.isInside(pos)) continue;
+                    BlockState state = level.getBlockState(pos);
+                    if (state.is(Blocks.BEDROCK)) break;
+                    if (state.isAir() || !state.getFluidState().isEmpty()) {
+                        level.setBlock(pos, getCraterLiner(random, variant), 2);
+                        solidStreak = 0;
+                    } else {
+                        solidStreak++;
+                        // Five consecutive solid blocks means we are past the opening
+                        if (solidStreak >= 5) break;
                     }
                 }
             }

--- a/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
@@ -195,6 +195,8 @@ public class MeteoriteStructurePiece extends StructurePiece {
      *   3. Meteorite sphere - place the iron core and stone shell
      *   4. Debris scatter - drop iron fragments on the crater floor
      *   5. Ejecta rim - scorched ring with occasional raised blocks at the crater edge
+     *   6. Fallen trees - biome-specific logs on the crater floor
+     *   7. Impact heat - fire and lava near the core for a fresh-impact look
      */
     @Override
     public void postProcess(WorldGenLevel level, StructureManager structureManager,
@@ -290,12 +292,13 @@ public class MeteoriteStructurePiece extends StructurePiece {
             }
         }
 
-        // Phase 1.5: Remove floating vines and leaves left after tree clearing.
-        // This pass does NOT respect chunkBox boundaries. Trees from adjacent
-        // chunks can place leaves into already-processed chunks. By clearing
-        // across chunk boundaries we catch leaves that appear after our Phase 1
-        // pass on an adjacent chunk has already finished. Setting blocks to air
-        // in loaded adjacent chunks is safe during postProcess.
+        // Phase 1.5: Remove ALL floating vegetation left after tree clearing.
+        // Not just vines and leaves -- also logs, mushroom blocks, bamboo, and
+        // any other vegetation that can end up hovering after the crater carves
+        // away the terrain beneath. Trees from adjacent chunks can place blocks
+        // into already-processed chunks, so this pass does NOT respect chunkBox
+        // boundaries. Setting blocks to air in loaded adjacent chunks is safe
+        // during postProcess.
         // Top-to-bottom scan so vine chains collapse correctly in a single pass.
         int floatClearRadius = craterRadius + 15;
         for (int dx = -floatClearRadius; dx <= floatClearRadius; dx++) {
@@ -312,10 +315,15 @@ public class MeteoriteStructurePiece extends StructurePiece {
                 for (int y = topY; y >= bottomY; y--) {
                     BlockPos pos = new BlockPos(bx, y, bz);
                     BlockState state = level.getBlockState(pos);
+                    // Remove unsupported vines
                     if (state.is(Blocks.VINE) && !hasVineSupport(level, pos)) {
                         level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2);
+                        continue;
                     }
-                    if (state.is(BlockTags.LEAVES)) {
+                    // Remove all leaves, logs, mushroom blocks, bamboo, and
+                    // other vegetation unconditionally in the clearing zone.
+                    // These should not be floating above the impact site.
+                    if (isVegetation(state)) {
                         level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2);
                     }
                 }
@@ -485,6 +493,72 @@ public class MeteoriteStructurePiece extends StructurePiece {
                         }
                     }
                 }
+            }
+        }
+
+        // Phase 7: Impact heat effects - fire and lava for a fresh-impact look.
+        // Fire is placed on the crater floor within the inner portion of the bowl.
+        // On magma blocks the fire stays permanently; on other blocks it dies out
+        // naturally over time, creating a sense of recency on discovery.
+        int fireRadius = (int) (craterRadius * 0.6);
+        for (int dx = -fireRadius; dx <= fireRadius; dx++) {
+            for (int dz = -fireRadius; dz <= fireRadius; dz++) {
+                double horizDist = Math.sqrt(dx * dx + dz * dz);
+                if (horizDist > fireRadius) continue;
+                // Sparse placement - roughly 15% of eligible positions get fire
+                if (random.nextInt(100) >= 15) continue;
+
+                int bx = centerX + dx;
+                int bz = centerZ + dz;
+                int floorY = getCraterFloorY(horizDist, craterRadius);
+                if (floorY >= surfaceY - 1) continue;
+
+                BlockPos firePos = new BlockPos(bx, floorY, bz);
+                if (!chunkBox.isInside(firePos)) continue;
+
+                BlockState atPos = level.getBlockState(firePos);
+                BlockState below = level.getBlockState(firePos.below());
+                // Place fire only in air on top of a solid, non-fluid block
+                if (atPos.isAir() && !below.isAir() && below.getFluidState().isEmpty()) {
+                    level.setBlock(firePos, Blocks.FIRE.defaultBlockState(), 2);
+                }
+            }
+        }
+
+        // Small lava pools near the meteor core for extreme-heat visuals.
+        // Place just outside the meteorite sphere so the lava ends up on the
+        // crater floor next to the rock. The previous approach tried to place
+        // inside the sphere radius where all positions are solid, so lava never
+        // appeared. Scan upward from floor to find the first air block above
+        // solid ground, which handles any debris or sphere surface blocks.
+        int lavaCount = 2 + random.nextInt(3);
+        for (int i = 0; i < lavaCount; i++) {
+            double angle = random.nextDouble() * Math.PI * 2;
+            double dist = meteorRadius + 1.0 + random.nextDouble() * meteorRadius * 0.6;
+            int lx = centerX + (int) Math.round(Math.cos(angle) * dist);
+            int lz = centerZ + (int) Math.round(Math.sin(angle) * dist);
+
+            double horizDist = Math.sqrt((lx - centerX) * (lx - centerX)
+                    + (lz - centerZ) * (lz - centerZ));
+            int floorY = getCraterFloorY(horizDist, craterRadius);
+            if (floorY >= surfaceY - 1) continue;
+
+            // Scan upward to find the first air block above solid ground.
+            // This handles cases where debris or the sphere surface is present.
+            BlockPos lavaPos = null;
+            for (int scanY = floorY; scanY < floorY + 10; scanY++) {
+                BlockPos candidate = new BlockPos(lx, scanY, lz);
+                if (!chunkBox.isInside(candidate)) break;
+                BlockState atScan = level.getBlockState(candidate);
+                BlockState belowScan = level.getBlockState(candidate.below());
+                if (atScan.isAir() && !belowScan.isAir()
+                        && belowScan.getFluidState().isEmpty()) {
+                    lavaPos = candidate;
+                    break;
+                }
+            }
+            if (lavaPos != null) {
+                level.setBlock(lavaPos, Blocks.LAVA.defaultBlockState(), 2);
             }
         }
     }

--- a/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
@@ -3,12 +3,15 @@ package anya.pizza.houseki.world.structure;
 import anya.pizza.houseki.block.ModBlocks;
 import anya.pizza.houseki.util.ModTags;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.StructureManager;
 import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkGenerator;
@@ -39,6 +42,13 @@ public class MeteoriteStructurePiece extends StructurePiece {
     private static final int CRATER_EXTRA = 25;
     // How far above the surface we clear blocks (to remove tall trees)
     private static final int TREE_CLEAR_HEIGHT = 60;
+
+    // Biome-specific visual variants for the meteor. Core blocks (METEORIC_IRON) and
+    // iron distribution stay the same across all variants; only the surrounding
+    // shell, crater lining, and ejecta rim adapt to the local biome.
+    private enum BiomeVariant {
+        DEFAULT, DESERT, MANGROVE, SNOWY
+    }
 
     private final int centerX;      // world X of the impact center
     private final int surfaceY;     // Y of the terrain surface at impact
@@ -102,6 +112,29 @@ public class MeteoriteStructurePiece extends StructurePiece {
     }
 
     /**
+     * Determines the visual variant based on the biome at the meteor center.
+     * Only affects crater lining, meteorite shell, and ejecta rim blocks.
+     * Core blocks (METEORIC_IRON) and debris are unchanged.
+     */
+    private BiomeVariant determineBiomeVariant(WorldGenLevel level) {
+        Holder<Biome> biome = level.getBiome(new BlockPos(centerX, surfaceY, centerZ));
+
+        if (biome.is(Biomes.DESERT)) {
+            return BiomeVariant.DESERT;
+        }
+        if (biome.is(Biomes.MANGROVE_SWAMP) || biome.is(Biomes.SWAMP)) {
+            return BiomeVariant.MANGROVE;
+        }
+        if (biome.is(Biomes.SNOWY_PLAINS) || biome.is(Biomes.SNOWY_TAIGA)
+                || biome.is(Biomes.SNOWY_BEACH) || biome.is(Biomes.SNOWY_SLOPES)
+                || biome.is(Biomes.FROZEN_PEAKS) || biome.is(Biomes.ICE_SPIKES)
+                || biome.is(Biomes.GROVE)) {
+            return BiomeVariant.SNOWY;
+        }
+        return BiomeVariant.DEFAULT;
+    }
+
+    /**
      * Main generation method. Called once per chunk that overlaps this piece's bounding box.
      * Uses a deterministic seed so the output is identical regardless of chunk load order.
      *
@@ -122,6 +155,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
         int settleAmount = 5;
         int meteorCenterY = (surfaceY - craterDepth) + meteorRadius - settleAmount;
         BlockPos meteorCenter = new BlockPos(centerX, meteorCenterY, centerZ);
+        BiomeVariant variant = determineBiomeVariant(level);
 
         // Bail out if the center is in water or lava - meteorites in oceans look bad
         BlockPos surfacePos = new BlockPos(centerX, surfaceY - 1, centerZ);
@@ -167,7 +201,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
                         if (!existing.isAir()) {
                             // Replace dirt, sand, grass, etc. with crater material
                             if (!meteorWontReplace(existing)) {
-                                level.setBlock(floorPos, getCraterLiner(random), 2);
+                                level.setBlock(floorPos, getCraterLiner(random, variant), 2);
                             }
                         }
                     }
@@ -231,7 +265,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
                     // Check if this block is exposed (has air neighbor)
                     if (isExposedToAir(level, pos, chunkBox)) {
                         if (!meteorWontReplace(state)) {
-                            level.setBlock(pos, getCraterLiner(random), 2);
+                            level.setBlock(pos, getCraterLiner(random, variant), 2);
                         }
                     }
                 }
@@ -249,7 +283,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
                     if (dist > meteorRadius + 0.5) continue;
 
                     double noise = (random.nextDouble() - 0.5) * 0.8;
-                    BlockState shellBlock = getShellBlock(random);
+                    BlockState shellBlock = getShellBlock(random, variant);
 
                     double noisyDist = dist + noise;
                     if (noisyDist > meteorRadius) continue;
@@ -293,9 +327,9 @@ public class MeteoriteStructurePiece extends StructurePiece {
                 double horizDist = Math.sqrt(dx * dx + dz * dz);
                 if (horizDist < craterRadius - 2.5 || horizDist > craterRadius + 2) continue;
 
-                BlockState rimBlock = getEjectaRim(random);
+                BlockState rimBlock = getEjectaRim(random, variant);
                 int rimRoll = random.nextInt(3);
-                BlockState raisedBlock = getEjectaRim(random);
+                BlockState raisedBlock = getEjectaRim(random, variant);
 
                 int bx = centerX + dx;
                 int bz = centerZ + dz;
@@ -357,35 +391,123 @@ public class MeteoriteStructurePiece extends StructurePiece {
         return false;
     }
 
-    // Weighted random palette for crater floors and walls
-    private BlockState getCraterLiner(Random random) {
+    // Weighted random palette for crater floors and walls, adapted to biome variant.
+    private BlockState getCraterLiner(Random random, BiomeVariant variant) {
         int roll = random.nextInt(11);
-        if (roll < 5) return Blocks.STONE.defaultBlockState();
-        if (roll < 7) return Blocks.COBBLESTONE.defaultBlockState();
-        if (roll < 8) return Blocks.MAGMA_BLOCK.defaultBlockState();
-        if (roll < 9) return Blocks.COBBLED_DEEPSLATE.defaultBlockState();
-        if (roll < 10) return Blocks.COAL_BLOCK.defaultBlockState();
-        return Blocks.GRAVEL.defaultBlockState();
+        return switch (variant) {
+            case DESERT -> {
+                if (roll < 5) yield Blocks.SANDSTONE.defaultBlockState();
+                if (roll < 7) yield Blocks.SMOOTH_SANDSTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.TERRACOTTA.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.RED_SANDSTONE.defaultBlockState();
+            }
+            case MANGROVE -> {
+                if (roll < 5) yield Blocks.MUD.defaultBlockState();
+                if (roll < 7) yield Blocks.PACKED_MUD.defaultBlockState();
+                if (roll < 8) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.CLAY.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.MUDDY_MANGROVE_ROOTS.defaultBlockState();
+            }
+            case SNOWY -> {
+                if (roll < 4) yield Blocks.SNOW_BLOCK.defaultBlockState();
+                if (roll < 6) yield Blocks.PACKED_ICE.defaultBlockState();
+                if (roll < 8) yield Blocks.STONE.defaultBlockState();
+                if (roll < 9) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.GRAVEL.defaultBlockState();
+            }
+            default -> {
+                if (roll < 5) yield Blocks.STONE.defaultBlockState();
+                if (roll < 7) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.GRAVEL.defaultBlockState();
+            }
+        };
     }
 
-    // Weighted random palette for the meteorite shell
-    private BlockState getShellBlock(Random random) {
+    // Weighted random palette for the meteorite shell, adapted to biome variant.
+    // Core blocks (METEORIC_IRON) are unaffected; only the outer shell changes.
+    private BlockState getShellBlock(Random random, BiomeVariant variant) {
         int roll = random.nextInt(11);
-        if (roll < 4) return Blocks.COBBLED_DEEPSLATE.defaultBlockState();
-        if (roll < 6) return Blocks.COBBLESTONE.defaultBlockState();
-        if (roll < 8) return Blocks.MAGMA_BLOCK.defaultBlockState();
-        if (roll < 10) return Blocks.COAL_BLOCK.defaultBlockState();
-        return Blocks.OBSIDIAN.defaultBlockState();
+        return switch (variant) {
+            case DESERT -> {
+                if (roll < 3) yield Blocks.SANDSTONE.defaultBlockState();
+                if (roll < 5) yield Blocks.SMOOTH_SANDSTONE.defaultBlockState();
+                if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.TERRACOTTA.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case MANGROVE -> {
+                if (roll < 3) yield Blocks.PACKED_MUD.defaultBlockState();
+                if (roll < 5) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.MUD.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case SNOWY -> {
+                if (roll < 3) yield Blocks.PACKED_ICE.defaultBlockState();
+                if (roll < 5) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.BLUE_ICE.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            default -> {
+                if (roll < 4) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 6) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+        };
     }
 
-    private BlockState getEjectaRim(Random random) {
+    // Weighted random palette for the ejecta rim around the crater, adapted to biome variant.
+    private BlockState getEjectaRim(Random random, BiomeVariant variant) {
         int roll = random.nextInt(11);
-        if (roll < 3) return Blocks.COBBLED_DEEPSLATE.defaultBlockState();
-        if (roll < 4) return Blocks.GRAVEL.defaultBlockState();
-        if (roll < 5) return Blocks.DIRT.defaultBlockState();
-        if (roll < 6) return Blocks.COBBLESTONE.defaultBlockState();
-        if (roll < 8) return Blocks.STONE.defaultBlockState();
-        if (roll < 10) return Blocks.COAL_BLOCK.defaultBlockState();
-        return Blocks.OBSIDIAN.defaultBlockState();
+        return switch (variant) {
+            case DESERT -> {
+                if (roll < 3) yield Blocks.TERRACOTTA.defaultBlockState();
+                if (roll < 4) yield Blocks.RED_SANDSTONE.defaultBlockState();
+                if (roll < 5) yield Blocks.SANDSTONE.defaultBlockState();
+                if (roll < 6) yield Blocks.SMOOTH_SANDSTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.CUT_SANDSTONE.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case MANGROVE -> {
+                if (roll < 3) yield Blocks.MUD.defaultBlockState();
+                if (roll < 4) yield Blocks.PACKED_MUD.defaultBlockState();
+                if (roll < 5) yield Blocks.CLAY.defaultBlockState();
+                if (roll < 6) yield Blocks.MUDDY_MANGROVE_ROOTS.defaultBlockState();
+                if (roll < 8) yield Blocks.MOSS_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case SNOWY -> {
+                if (roll < 3) yield Blocks.SNOW_BLOCK.defaultBlockState();
+                if (roll < 5) yield Blocks.PACKED_ICE.defaultBlockState();
+                if (roll < 7) yield Blocks.STONE.defaultBlockState();
+                if (roll < 8) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            default -> {
+                if (roll < 3) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 4) yield Blocks.GRAVEL.defaultBlockState();
+                if (roll < 5) yield Blocks.DIRT.defaultBlockState();
+                if (roll < 6) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.STONE.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+        };
     }
 }

--- a/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
@@ -3,8 +3,10 @@ package anya.pizza.houseki.world.structure;
 import anya.pizza.houseki.block.ModBlocks;
 import anya.pizza.houseki.util.ModTags;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.ChunkPos;
@@ -13,6 +15,7 @@ import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.RotatedPillarBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.levelgen.Heightmap;
@@ -47,7 +50,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
     // iron distribution stay the same across all variants; only the surrounding
     // shell, crater lining, and ejecta rim adapt to the local biome.
     private enum BiomeVariant {
-        DEFAULT, DESERT, MANGROVE, SNOWY
+        DEFAULT, DESERT, MANGROVE, SNOWY, JUNGLE, TAIGA, BADLANDS, SAVANNA, CHERRY, MUSHROOM, DARK_FOREST
     }
 
     private final int centerX;      // world X of the impact center
@@ -86,10 +89,11 @@ public class MeteoriteStructurePiece extends StructurePiece {
     }
 
     // Computes the bounding box that fully encloses the structure.
-    // Horizontal: meteorite + crater + small buffer for the ejecta rim.
+    // Horizontal: meteorite + crater + enough buffer for the full vegetation
+    // clearing zone (floatClearRadius = craterRadius + 15) plus ejecta rim.
     // Vertical: deep enough for the sphere at crater bottom, high enough to clear trees.
     private static BoundingBox makeBounds(int cx, int sy, int cz, int r, int depth) {
-        int extent = r + CRATER_EXTRA + 6;
+        int extent = r + CRATER_EXTRA + 17;
         return new BoundingBox(cx - extent, sy - depth - r - 2, cz - extent,
                 cx + extent, sy + TREE_CLEAR_HEIGHT, cz + extent);
     }
@@ -106,14 +110,25 @@ public class MeteoriteStructurePiece extends StructurePiece {
     }
 
     // Returns the Y of the crater floor at a given horizontal distance from center.
-    // Uses a quadratic curve (depthFraction^2) to create a smooth bowl shape:
-    // deepest at the center, gradually rising to surface level at the edges.
+    // Uses the local terrain height so the bowl blends into the surrounding
+    // landscape. On flat terrain this is identical to using surfaceY. On hillsides
+    // the bowl naturally carves into the hill instead of creating a cliff face.
+    private int getCraterFloorY(double horizDist, int craterRadius, int localTerrainY) {
+        if (horizDist > craterRadius) return localTerrainY;
+        double ratio = horizDist / craterRadius;
+        double bowlCurve = Math.cos(Math.PI * 0.5 * ratio);
+        bowlCurve = bowlCurve * bowlCurve;
+        int centerFloor = surfaceY - craterDepth;
+        // Blend: at center (bowlCurve=1) -> centerFloor
+        //        at rim   (bowlCurve=0) -> localTerrainY
+        return localTerrainY + (int) (bowlCurve * (centerFloor - localTerrainY));
+    }
+
+    // Convenience overload that uses surfaceY as the local terrain height.
+    // Gives the same result as the old formula on flat terrain and is safe to
+    // call from phases where the original terrain height is no longer available.
     private int getCraterFloorY(double horizDist, int craterRadius) {
-        if (horizDist > craterRadius) return surfaceY;
-        double distanceRatio = horizDist / craterRadius;
-        double bowlCurve = Math.sqrt(1.0 - (distanceRatio * distanceRatio));
-        int localDepth = (int) (craterDepth * bowlCurve);
-        return surfaceY - localDepth;
+        return getCraterFloorY(horizDist, craterRadius, surfaceY);
     }
 
     /**
@@ -133,6 +148,31 @@ public class MeteoriteStructurePiece extends StructurePiece {
                 || biome.is(Biomes.GROVE)) {
             return BiomeVariant.SNOWY.ordinal();
         }
+        if (biome.is(Biomes.JUNGLE) || biome.is(Biomes.SPARSE_JUNGLE)
+                || biome.is(Biomes.BAMBOO_JUNGLE)) {
+            return BiomeVariant.JUNGLE.ordinal();
+        }
+        if (biome.is(Biomes.TAIGA) || biome.is(Biomes.OLD_GROWTH_PINE_TAIGA)
+                || biome.is(Biomes.OLD_GROWTH_SPRUCE_TAIGA)) {
+            return BiomeVariant.TAIGA.ordinal();
+        }
+        if (biome.is(Biomes.BADLANDS) || biome.is(Biomes.ERODED_BADLANDS)
+                || biome.is(Biomes.WOODED_BADLANDS)) {
+            return BiomeVariant.BADLANDS.ordinal();
+        }
+        if (biome.is(Biomes.SAVANNA) || biome.is(Biomes.SAVANNA_PLATEAU)
+                || biome.is(Biomes.WINDSWEPT_SAVANNA)) {
+            return BiomeVariant.SAVANNA.ordinal();
+        }
+        if (biome.is(Biomes.CHERRY_GROVE)) {
+            return BiomeVariant.CHERRY.ordinal();
+        }
+        if (biome.is(Biomes.MUSHROOM_FIELDS)) {
+            return BiomeVariant.MUSHROOM.ordinal();
+        }
+        if (biome.is(Biomes.DARK_FOREST)) {
+            return BiomeVariant.DARK_FOREST.ordinal();
+        }
         return BiomeVariant.DEFAULT.ordinal();
     }
 
@@ -149,8 +189,9 @@ public class MeteoriteStructurePiece extends StructurePiece {
      * Uses a deterministic seed so the output is identical regardless of chunk load order.
      *
      * Phases:
-     *   1. Crater excavation - dig the bowl and clear trees
-     *   2. Wall lining - replace exposed non-stone blocks with scorched material
+     *   1. Crater excavation - dig the bowl and clear trees/vegetation
+     *   1.5 Float cleanup - remove leftover vines and leaves
+     *   2. Cave sealing - fill cave/ravine gaps beneath the crater
      *   3. Meteorite sphere - place the iron core and stone shell
      *   4. Debris scatter - drop iron fragments on the crater floor
      *   5. Ejecta rim - scorched ring with occasional raised blocks at the crater edge
@@ -167,35 +208,47 @@ public class MeteoriteStructurePiece extends StructurePiece {
         BlockPos meteorCenter = new BlockPos(centerX, meteorCenterY, centerZ);
         BiomeVariant variant = getVariant();
 
-        // Bail out on lava for all variants. Bail out on water only for DEFAULT
-        // and DESERT variants. Swamp/Mangrove and Snowy biomes commonly have water
-        // surfaces and are allowed to generate with water present.
-        BlockPos surfacePos = new BlockPos(centerX, surfaceY - 1, centerZ);
-        BlockState surfaceState = level.getBlockState(surfacePos);
-        if (surfaceState.getFluidState().is(FluidTags.LAVA)) {
-            return;
-        }
-        if (surfaceState.getFluidState().is(FluidTags.WATER)
-                && variant != BiomeVariant.MANGROVE && variant != BiomeVariant.SNOWY) {
-            return;
+        // Bail out on lava or water for all variants.
+        // Check center and 4 cardinal points at half crater radius to catch
+        // nearby lakes/rivers that the biome check can't detect.
+        int waterCheckDist = craterRadius / 2;
+        int[][] waterChecks = {{0, 0}, {waterCheckDist, 0}, {-waterCheckDist, 0},
+                {0, waterCheckDist}, {0, -waterCheckDist}};
+        for (int[] wc : waterChecks) {
+            int wx = centerX + wc[0];
+            int wz = centerZ + wc[1];
+            int wy = level.getHeight(Heightmap.Types.WORLD_SURFACE, wx, wz) - 1;
+            BlockState wcState = level.getBlockState(new BlockPos(wx, wy, wz));
+            if (wcState.getFluidState().is(FluidTags.LAVA)) {
+                return;
+            }
+            if (wcState.getFluidState().is(FluidTags.WATER)) {
+                return;
+            }
         }
 
-        // Phase 1: Clear EVERYTHING in crater area (trees, vegetation, terrain)
-        // and line exposed walls/floor with crater material
-        for (int dx = -craterRadius - 2; dx <= craterRadius + 2; dx++) {
-            for (int dz = -craterRadius - 2; dz <= craterRadius + 2; dz++) {
+        // Phase 1: Terrain-adaptive crater excavation and vegetation clearing.
+        // The bowl depth is computed relative to the local terrain height so the
+        // crater blends smoothly into hillsides instead of creating cliff faces.
+        // Vegetation (trees, leaves, etc.) is cleared in a wider zone around the
+        // crater to prevent floating canopies.
+        int vegClearRadius = craterRadius + 12;
+        for (int dx = -vegClearRadius; dx <= vegClearRadius; dx++) {
+            for (int dz = -vegClearRadius; dz <= vegClearRadius; dz++) {
                 double horizDist = Math.sqrt(dx * dx + dz * dz);
-                if (horizDist > craterRadius + 5) continue;
+                if (horizDist > vegClearRadius) continue;
 
                 int bx = centerX + dx;
                 int bz = centerZ + dz;
-                int actualSurfaceY = level.getHeight(Heightmap.Types.WORLD_SURFACE, bx, bz);
-                int topClearY = Math.max(actualSurfaceY, surfaceY) + TREE_CLEAR_HEIGHT;
-                int craterFloorY = getCraterFloorY(horizDist, craterRadius);
+                int rawSurfaceY = level.getHeight(Heightmap.Types.WORLD_SURFACE, bx, bz);
+                int groundY = getGroundLevel(level, bx, bz, rawSurfaceY);
+                int topClearY = Math.max(rawSurfaceY, surfaceY) + TREE_CLEAR_HEIGHT;
 
                 boolean insideCrater = horizDist <= craterRadius;
 
                 if (insideCrater) {
+                    int craterFloorY = getCraterFloorY(horizDist, craterRadius, groundY);
+
                     // Clear everything from high above (trees!) down to crater floor
                     for (int y = topClearY; y >= craterFloorY; y--) {
                         BlockPos pos = new BlockPos(bx, y, bz);
@@ -220,13 +273,16 @@ public class MeteoriteStructurePiece extends StructurePiece {
                             }
                         }
                     }
-                } else if (horizDist <= craterRadius + 2) {
-                    // Near-rim: clear trees and vegetation above terrain
-                    for (int y = topClearY; y > actualSurfaceY; y--) {
+                } else {
+                    // Outside crater: clear all vegetation above ground level.
+                    // This prevents floating canopies from trees partially inside
+                    // the crater or near the rim.
+                    for (int y = topClearY; y >= groundY; y--) {
                         BlockPos pos = new BlockPos(bx, y, bz);
                         if (!chunkBox.isInside(pos)) continue;
                         BlockState state = level.getBlockState(pos);
-                        if (!state.isAir() && !state.is(Blocks.BEDROCK)) {
+                        if (!state.isAir() && !state.is(Blocks.BEDROCK)
+                                && isVegetation(state)) {
                             level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2);
                         }
                     }
@@ -234,15 +290,19 @@ public class MeteoriteStructurePiece extends StructurePiece {
             }
         }
 
-        // Phase 1.5: Remove floating vines left after tree clearing
-        // In jungle biomes, vines attached to cleared trees are left hanging in mid-air.
+        // Phase 1.5: Remove floating vines and leaves left after tree clearing.
+        // This pass does NOT respect chunkBox boundaries. Trees from adjacent
+        // chunks can place leaves into already-processed chunks. By clearing
+        // across chunk boundaries we catch leaves that appear after our Phase 1
+        // pass on an adjacent chunk has already finished. Setting blocks to air
+        // in loaded adjacent chunks is safe during postProcess.
         // Top-to-bottom scan so vine chains collapse correctly in a single pass.
-        int vineRadius = craterRadius + 5;
-        for (int dx = -vineRadius; dx <= vineRadius; dx++) {
-            for (int dz = -vineRadius; dz <= vineRadius; dz++) {
+        int floatClearRadius = craterRadius + 15;
+        for (int dx = -floatClearRadius; dx <= floatClearRadius; dx++) {
+            for (int dz = -floatClearRadius; dz <= floatClearRadius; dz++) {
                 double horizDist = Math.sqrt(dx * dx + dz * dz);
 
-                if (horizDist > vineRadius) continue;
+                if (horizDist > floatClearRadius) continue;
 
                 int bx = centerX + dx;
                 int bz = centerZ + dz;
@@ -251,47 +311,24 @@ public class MeteoriteStructurePiece extends StructurePiece {
 
                 for (int y = topY; y >= bottomY; y--) {
                     BlockPos pos = new BlockPos(bx, y, bz);
-                    if (!chunkBox.isInside(pos)) continue;
                     BlockState state = level.getBlockState(pos);
                     if (state.is(Blocks.VINE) && !hasVineSupport(level, pos)) {
+                        level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2);
+                    }
+                    if (state.is(BlockTags.LEAVES)) {
                         level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2);
                     }
                 }
             }
         }
 
-        // Phase 2: Line crater walls - replace any exposed non-stone blocks
-        for (int dx = -craterRadius; dx <= craterRadius; dx++) {
-            for (int dz = -craterRadius; dz <= craterRadius; dz++) {
-                double horizDist = Math.sqrt(dx * dx + dz * dz);
-                if (horizDist > craterRadius) continue;
-
-                int bx = centerX + dx;
-                int bz = centerZ + dz;
-                int craterFloorY = getCraterFloorY(horizDist, craterRadius);
-
-                // Scan the wall: from crater floor up to where it meets terrain
-                for (int y = craterFloorY - 1; y <= surfaceY; y++) {
-                    BlockPos pos = new BlockPos(bx, y, bz);
-                    if (!chunkBox.isInside(pos)) continue;
-                    BlockState state = level.getBlockState(pos);
-                    if (state.isAir() || state.is(Blocks.BEDROCK)) continue;
-
-                    // Check if this block is exposed (has air neighbor)
-                    if (isExposedToAir(level, pos, chunkBox)) {
-                        if (!meteorWontReplace(state)) {
-                            level.setBlock(pos, getCraterLiner(random, variant), 2);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Phase 2.5: Seal caves and ravines beneath the crater.
+        // Phase 2: Seal caves and ravines beneath the crater.
         // Carvers (caves, ravines) run before structures and may have opened gaps
         // below the crater floor that would be visible from inside. Scan downward
         // from just below the 2-block liner and fill any air or fluid pockets until
         // we hit a thick enough stretch of solid material.
+        // Only runs where local terrain is within 6 blocks of surfaceY to avoid
+        // filling natural terrain gaps near water/cliff edges.
         int sealDepth = craterDepth + meteorRadius;
         for (int dx = -craterRadius - 1; dx <= craterRadius + 1; dx++) {
             for (int dz = -craterRadius - 1; dz <= craterRadius + 1; dz++) {
@@ -300,7 +337,15 @@ public class MeteoriteStructurePiece extends StructurePiece {
 
                 int bx = centerX + dx;
                 int bz = centerZ + dz;
-                int craterFloorY = getCraterFloorY(horizDist, craterRadius);
+                int rawSY = level.getHeight(Heightmap.Types.WORLD_SURFACE, bx, bz);
+                int groundY = getGroundLevel(level, bx, bz, rawSY);
+
+                // Skip columns where terrain is much lower than surfaceY.
+                // These are natural terrain drops (water edges, cliffs) — not
+                // caves that need sealing. Filling them creates artificial walls.
+                if (surfaceY - groundY > 6) continue;
+
+                int craterFloorY = getCraterFloorY(horizDist, craterRadius, groundY);
 
                 int solidStreak = 0;
                 for (int y = craterFloorY - 3; y >= craterFloorY - sealDepth; y--) {
@@ -369,19 +414,22 @@ public class MeteoriteStructurePiece extends StructurePiece {
             }
         }
 
-        // Phase 5: Scorched ejecta rim at actual terrain height
+        // Phase 5: Scorched ejecta rim at actual terrain height.
+        // Only applied where terrain is roughly level with the impact center.
+        // Skipped on steep hillsides to avoid artificial-looking material bands.
         for (int dx = -craterRadius - 2; dx <= craterRadius + 2; dx++) {
             for (int dz = -craterRadius - 2; dz <= craterRadius + 2; dz++) {
                 double horizDist = Math.sqrt(dx * dx + dz * dz);
                 if (horizDist < craterRadius - 2.5 || horizDist > craterRadius + 2) continue;
 
-                BlockState rimBlock = getEjectaRim(random, variant);
-                int rimRoll = random.nextInt(3);
-                BlockState raisedBlock = getEjectaRim(random, variant);
-
                 int bx = centerX + dx;
                 int bz = centerZ + dz;
                 int actualY = level.getHeight(Heightmap.Types.WORLD_SURFACE, bx, bz);
+
+                // Skip rim on steep terrain to avoid artificial bands on hillsides
+                if (Math.abs(actualY - surfaceY) > 4) continue;
+
+                BlockState rimBlock = getEjectaRim(random, variant);
 
                 // Replace surface block with rim material
                 BlockPos rimPos = new BlockPos(bx, actualY - 1, bz);
@@ -392,12 +440,49 @@ public class MeteoriteStructurePiece extends StructurePiece {
                         level.setBlock(rimPos, rimBlock, 2);
                     }
                 }
+            }
+        }
 
-                // Raised rim blocks
-                if (rimRoll == 0 && horizDist >= craterRadius - 1 && horizDist <= craterRadius + 0.5) {
-                    BlockPos aboveRim = new BlockPos(bx, actualY, bz);
-                    if (chunkBox.isInside(aboveRim) && level.getBlockState(aboveRim).isAir()) {
-                        level.setBlock(aboveRim, raisedBlock, 2);
+        // Phase 6: Place fallen trees for biome flavor.
+        // Only for biomes that naturally have trees. Logs lie flat on the crater
+        // floor/slope as if knocked down by the impact.
+        BlockState fallenLog = getFallenLogBlock(variant);
+        if (fallenLog != null) {
+            int treeCount = 1 + random.nextInt(3);
+            for (int t = 0; t < treeCount; t++) {
+                double angle = random.nextDouble() * Math.PI * 2;
+                double dist = craterRadius * 0.3 + random.nextDouble() * craterRadius * 0.5;
+                int tx = centerX + (int) Math.round(Math.cos(angle) * dist);
+                int tz = centerZ + (int) Math.round(Math.sin(angle) * dist);
+
+                double hd = Math.sqrt((tx - centerX) * (tx - centerX) + (tz - centerZ) * (tz - centerZ));
+                int floorY = getCraterFloorY(hd, craterRadius);
+                if (floorY >= surfaceY - 1) continue;
+
+                // Pick a random horizontal direction for the log
+                boolean alongX = random.nextBoolean();
+                Direction.Axis axis = alongX ? Direction.Axis.X : Direction.Axis.Z;
+                BlockState log = fallenLog.setValue(RotatedPillarBlock.AXIS, axis);
+
+                int length = 3 + random.nextInt(5);
+                for (int i = 0; i < length; i++) {
+                    int lx = alongX ? tx + i : tx;
+                    int lz = alongX ? tz : tz + i;
+
+                    double ld = Math.sqrt((lx - centerX) * (lx - centerX) + (lz - centerZ) * (lz - centerZ));
+                    if (ld > craterRadius) break;
+
+                    int ly = getCraterFloorY(ld, craterRadius);
+                    BlockPos logPos = new BlockPos(lx, ly, lz);
+                    if (!chunkBox.isInside(logPos)) continue;
+
+                    BlockState existing = level.getBlockState(logPos);
+                    if (existing.isAir()) {
+                        // Verify the block below is solid so the log does not float
+                        BlockState below = level.getBlockState(logPos.below());
+                        if (!below.isAir() && below.getFluidState().isEmpty()) {
+                            level.setBlock(logPos, log, 2);
+                        }
                     }
                 }
             }
@@ -416,27 +501,71 @@ public class MeteoriteStructurePiece extends StructurePiece {
         return !level.getBlockState(pos.above()).isAir();
     }
 
+    // A leaf block is considered supported if it has at least one non-air,
+    // non-leaf neighbor (i.e. a log, solid terrain, or similar). During a
+    // top-to-bottom scan, previously removed leaves above read as air, so
+    // unsupported clusters collapse correctly.
+    private boolean hasLeafSupport(WorldGenLevel level, BlockPos pos) {
+        for (BlockPos neighbor : new BlockPos[]{
+                pos.above(), pos.below(),
+                pos.north(), pos.east(), pos.south(), pos.west()}) {
+            BlockState s = level.getBlockState(neighbor);
+            if (!s.isAir() && !s.is(BlockTags.LEAVES)) return true;
+        }
+        return false;
+    }
+
+    // Returns true if the block is part of a tree or vegetation (leaves, logs,
+    // vines, grass, flowers, mushroom blocks, etc.). Used by the ground-level
+    // scanner and the outer vegetation clearing zone.
+    private boolean isVegetation(BlockState state) {
+        return state.is(BlockTags.LEAVES) || state.is(BlockTags.LOGS)
+                || state.is(Blocks.VINE) || state.is(Blocks.MOSS_CARPET)
+                || state.is(Blocks.SHORT_GRASS) || state.is(Blocks.TALL_GRASS)
+                || state.is(Blocks.FERN) || state.is(Blocks.LARGE_FERN)
+                || state.is(Blocks.DEAD_BUSH) || state.is(Blocks.BAMBOO)
+                || state.is(Blocks.SUGAR_CANE) || state.is(Blocks.COCOA)
+                || state.is(Blocks.MUSHROOM_STEM)
+                || state.is(Blocks.BROWN_MUSHROOM_BLOCK)
+                || state.is(Blocks.RED_MUSHROOM_BLOCK)
+                || state.is(Blocks.BEE_NEST)
+                || state.is(Blocks.MANGROVE_ROOTS)
+                || state.is(Blocks.HANGING_ROOTS);
+    }
+
+    // Finds the actual ground level at a position, skipping tree canopies and
+    // other vegetation. Returns the Y of the topmost non-vegetation solid block
+    // plus one (the first air block above ground).
+    private int getGroundLevel(WorldGenLevel level, int x, int z, int rawSurfaceY) {
+        for (int y = rawSurfaceY - 1; y > level.getMinY(); y--) {
+            BlockState state = level.getBlockState(new BlockPos(x, y, z));
+            if (state.isAir()) continue;
+            if (isVegetation(state)) continue;
+            return y + 1;
+        }
+        return rawSurfaceY;
+    }
+
     private boolean meteorWontReplace(BlockState state) {
         return state.is(ModTags.Blocks.METEOR_WONT_REPLACE);
     }
 
-    // Checks all 6 neighbors. If any is air (and within the chunk box), the block is "exposed"
-    // and should be lined with crater material in Phase 2.
-    private boolean isExposedToAir(WorldGenLevel world, BlockPos pos, BoundingBox box) {
-        for (int i = 0; i < 6; i++) {
-            BlockPos neighbor = switch (i) {
-                case 0 -> pos.above();
-                case 1 -> pos.below();
-                case 2 -> pos.north();
-                case 3 -> pos.south();
-                case 4 -> pos.east();
-                default -> pos.west();
-            };
-            if (box.isInside(neighbor) && world.getBlockState(neighbor).isAir()) {
-                return true;
-            }
-        }
-        return false;
+    // Returns the appropriate log block for fallen trees, or null if the biome
+    // should not have fallen trees (arid or treeless biomes).
+    private BlockState getFallenLogBlock(BiomeVariant variant) {
+        return switch (variant) {
+            case DEFAULT -> Blocks.OAK_LOG.defaultBlockState();
+            case DESERT -> null;
+            case MANGROVE -> Blocks.MANGROVE_LOG.defaultBlockState();
+            case SNOWY -> Blocks.SPRUCE_LOG.defaultBlockState();
+            case JUNGLE -> Blocks.JUNGLE_LOG.defaultBlockState();
+            case TAIGA -> Blocks.SPRUCE_LOG.defaultBlockState();
+            case BADLANDS -> null;
+            case SAVANNA -> Blocks.ACACIA_LOG.defaultBlockState();
+            case CHERRY -> Blocks.CHERRY_LOG.defaultBlockState();
+            case MUSHROOM -> null;
+            case DARK_FOREST -> Blocks.DARK_OAK_LOG.defaultBlockState();
+        };
     }
 
     // Weighted random palette for crater floors and walls, adapted to biome variant.
@@ -467,6 +596,64 @@ public class MeteoriteStructurePiece extends StructurePiece {
                 if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
                 yield Blocks.GRAVEL.defaultBlockState();
             }
+            case JUNGLE -> {
+                if (roll < 4) yield Blocks.MOSS_BLOCK.defaultBlockState();
+                if (roll < 6) yield Blocks.MUD.defaultBlockState();
+                if (roll < 8) yield Blocks.STONE.defaultBlockState();
+                if (roll < 9) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.ROOTED_DIRT.defaultBlockState();
+            }
+            case TAIGA -> {
+                if (roll < 4) yield Blocks.PODZOL.defaultBlockState();
+                if (roll < 6) yield Blocks.COARSE_DIRT.defaultBlockState();
+                if (roll < 8) yield Blocks.STONE.defaultBlockState();
+                if (roll < 9) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.GRAVEL.defaultBlockState();
+            }
+            case BADLANDS -> {
+                if (roll < 3) yield Blocks.TERRACOTTA.defaultBlockState();
+                if (roll < 5) yield Blocks.ORANGE_TERRACOTTA.defaultBlockState();
+                if (roll < 7) yield Blocks.RED_SANDSTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.YELLOW_TERRACOTTA.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.BROWN_TERRACOTTA.defaultBlockState();
+            }
+            case SAVANNA -> {
+                if (roll < 4) yield Blocks.COARSE_DIRT.defaultBlockState();
+                if (roll < 6) yield Blocks.STONE.defaultBlockState();
+                if (roll < 8) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 9) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.GRAVEL.defaultBlockState();
+            }
+            case CHERRY -> {
+                if (roll < 4) yield Blocks.STONE.defaultBlockState();
+                if (roll < 6) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 7) yield Blocks.MOSS_BLOCK.defaultBlockState();
+                if (roll < 8) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.CLAY.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.GRAVEL.defaultBlockState();
+            }
+            case MUSHROOM -> {
+                if (roll < 4) yield Blocks.MYCELIUM.defaultBlockState();
+                if (roll < 6) yield Blocks.STONE.defaultBlockState();
+                if (roll < 8) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 9) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.GRAVEL.defaultBlockState();
+            }
+            case DARK_FOREST -> {
+                if (roll < 4) yield Blocks.ROOTED_DIRT.defaultBlockState();
+                if (roll < 6) yield Blocks.COARSE_DIRT.defaultBlockState();
+                if (roll < 8) yield Blocks.STONE.defaultBlockState();
+                if (roll < 9) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+            }
             default -> {
                 if (roll < 5) yield Blocks.STONE.defaultBlockState();
                 if (roll < 7) yield Blocks.COBBLESTONE.defaultBlockState();
@@ -480,6 +667,7 @@ public class MeteoriteStructurePiece extends StructurePiece {
 
     // Weighted random palette for the meteorite shell, adapted to biome variant.
     // Core blocks (METEORIC_IRON) are unaffected; only the outer shell changes.
+    // Represents local geology fused into the meteor shell on impact.
     private BlockState getShellBlock(Random random, BiomeVariant variant) {
         int roll = random.nextInt(11);
         return switch (variant) {
@@ -505,6 +693,54 @@ public class MeteoriteStructurePiece extends StructurePiece {
                 if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
                 if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
                 if (roll < 10) yield Blocks.BLUE_ICE.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case JUNGLE, DARK_FOREST -> {
+                if (roll < 3) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 5) yield Blocks.MOSS_BLOCK.defaultBlockState();
+                if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.STONE.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case TAIGA -> {
+                if (roll < 3) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 5) yield Blocks.STONE.defaultBlockState();
+                if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COBBLESTONE.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case BADLANDS -> {
+                if (roll < 3) yield Blocks.TERRACOTTA.defaultBlockState();
+                if (roll < 5) yield Blocks.RED_SANDSTONE.defaultBlockState();
+                if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.ORANGE_TERRACOTTA.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case SAVANNA -> {
+                if (roll < 3) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 5) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.STONE.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case CHERRY -> {
+                if (roll < 3) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 5) yield Blocks.STONE.defaultBlockState();
+                if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.CLAY.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case MUSHROOM -> {
+                if (roll < 3) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 5) yield Blocks.STONE.defaultBlockState();
+                if (roll < 7) yield Blocks.MAGMA_BLOCK.defaultBlockState();
+                if (roll < 9) yield Blocks.COAL_BLOCK.defaultBlockState();
+                if (roll < 10) yield Blocks.COBBLESTONE.defaultBlockState();
                 yield Blocks.OBSIDIAN.defaultBlockState();
             }
             default -> {
@@ -544,6 +780,69 @@ public class MeteoriteStructurePiece extends StructurePiece {
                 if (roll < 5) yield Blocks.PACKED_ICE.defaultBlockState();
                 if (roll < 7) yield Blocks.STONE.defaultBlockState();
                 if (roll < 8) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case JUNGLE -> {
+                if (roll < 3) yield Blocks.MOSS_BLOCK.defaultBlockState();
+                if (roll < 4) yield Blocks.MUD.defaultBlockState();
+                if (roll < 5) yield Blocks.ROOTED_DIRT.defaultBlockState();
+                if (roll < 6) yield Blocks.COARSE_DIRT.defaultBlockState();
+                if (roll < 8) yield Blocks.STONE.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case TAIGA -> {
+                if (roll < 3) yield Blocks.PODZOL.defaultBlockState();
+                if (roll < 4) yield Blocks.COARSE_DIRT.defaultBlockState();
+                if (roll < 5) yield Blocks.STONE.defaultBlockState();
+                if (roll < 6) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.GRAVEL.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case BADLANDS -> {
+                if (roll < 3) yield Blocks.TERRACOTTA.defaultBlockState();
+                if (roll < 4) yield Blocks.ORANGE_TERRACOTTA.defaultBlockState();
+                if (roll < 5) yield Blocks.YELLOW_TERRACOTTA.defaultBlockState();
+                if (roll < 6) yield Blocks.RED_SANDSTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.BROWN_TERRACOTTA.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case SAVANNA -> {
+                if (roll < 3) yield Blocks.COARSE_DIRT.defaultBlockState();
+                if (roll < 4) yield Blocks.GRAVEL.defaultBlockState();
+                if (roll < 5) yield Blocks.DIRT.defaultBlockState();
+                if (roll < 6) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.STONE.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case CHERRY -> {
+                if (roll < 3) yield Blocks.STONE.defaultBlockState();
+                if (roll < 4) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 5) yield Blocks.CLAY.defaultBlockState();
+                if (roll < 6) yield Blocks.MOSS_BLOCK.defaultBlockState();
+                if (roll < 8) yield Blocks.GRAVEL.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case MUSHROOM -> {
+                if (roll < 3) yield Blocks.MYCELIUM.defaultBlockState();
+                if (roll < 4) yield Blocks.STONE.defaultBlockState();
+                if (roll < 5) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 6) yield Blocks.GRAVEL.defaultBlockState();
+                if (roll < 8) yield Blocks.DIRT.defaultBlockState();
+                if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
+                yield Blocks.OBSIDIAN.defaultBlockState();
+            }
+            case DARK_FOREST -> {
+                if (roll < 3) yield Blocks.ROOTED_DIRT.defaultBlockState();
+                if (roll < 4) yield Blocks.COARSE_DIRT.defaultBlockState();
+                if (roll < 5) yield Blocks.COBBLED_DEEPSLATE.defaultBlockState();
+                if (roll < 6) yield Blocks.COBBLESTONE.defaultBlockState();
+                if (roll < 8) yield Blocks.STONE.defaultBlockState();
                 if (roll < 10) yield Blocks.COAL_BLOCK.defaultBlockState();
                 yield Blocks.OBSIDIAN.defaultBlockState();
             }

--- a/src/main/java/anya/pizza/houseki/world/structure/ModStructures.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/ModStructures.java
@@ -8,6 +8,7 @@ import net.minecraft.data.worldgen.BootstrapContext;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.BiomeTags;
+import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.levelgen.structure.StructureSet;
 import net.minecraft.world.level.levelgen.structure.StructureType;
@@ -43,13 +44,18 @@ public class ModStructures {
 
     /**
      * Called during datagen. Creates the meteorite structure and restricts it to Overworld biomes.
+     * Uses TOP_LAYER_MODIFICATION step so the crater carving runs after all features
+     * (including trees from VEGETAL_DECORATION), preventing vegetation from spawning
+     * inside the crater.
      * Produces: data/houseki/worldgen/structure/meteorite.json
      */
     public static void bootstrapStructure(BootstrapContext<Structure> context) {
         var biomes = context.lookup(Registries.BIOME);
 
         context.register(METEORITE_KEY, new MeteoriteStructure(
-                new Structure.StructureSettings.Builder(biomes.getOrThrow(BiomeTags.IS_OVERWORLD)).build()
+                new Structure.StructureSettings.Builder(biomes.getOrThrow(BiomeTags.IS_OVERWORLD))
+                        .generationStep(GenerationStep.Decoration.TOP_LAYER_MODIFICATION)
+                        .build()
         ));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Biome-dependent meteor variants**: Added 11 biome-specific visual variants (desert, mangrove/swamp, snowy, jungle, taiga, badlands, savanna, cherry, mushroom, dark forest) with distinct crater liners, shells, ejecta palettes, and fallen tree placement in forested biomes
- **Terrain-adaptive crater generation**: Crater bowl now follows surrounding landscape and rejects steep/rough locations; increased vegetation clearing radius extends across chunks with comprehensive removal of all vegetation types
- **Improved water and biome detection**: Enhanced rejection logic prevents generation in ocean, river, beach, and shore biomes; uses dual-height sampling (WORLD_SURFACE_WG and OCEAN_FLOOR_WG) to detect water presence and reject unsuitable locations
- **Generation step optimization**: Moved generation to TOP_LAYER_MODIFICATION phase ensuring structures place after features without overlapping vegetation
- **Impact heat effects**: Added sparse fire on crater floor (±15% density), persistent fire on magma blocks, and lava source blocks outside meteor sphere
- **Robustness improvements**: Prevented cascading block updates by excluding gravity-affected blocks from crater liner/shell; fixed cave sealing behavior, chunk-safe structure access to avoid crashes, lava placement correction, and removed postProcess registration check causing /locate ghost entries
- **Housekeeping**: Added .gitignore entries for decompiled output; configured .gitattributes for consistent line endings (LF for .json/.java, CRLF for .bat)

## Contributions by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| Tom Vetter | 725 | 107 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->