### PR TITLE
1.21.11 - Add REI compatibility for Crusher & Foundry 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ repositories {
 		name = "TerraformersMC"
 		url = "https://maven.terraformersmc.com/"
 	}
+	maven { url "https://maven.shedaniel.me/" }
+	maven { url "https://maven.architectury.dev/" }
 }
 
 fabricApi {
@@ -32,6 +34,12 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 	modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}")
+
+	modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}"
+	modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
+
+	modApi "dev.architectury:architectury-fabric:${project.architectury_version}"
+	modApi "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@ archives_base_name=houseki
 # Dependencies
 fabric_version=0.141.3+1.21.11
 modmenu_version=17.0.0-beta.2
+rei_version=21.11.814
+architectury_version=19.0.1
+cloth_config_version=21.11.153

--- a/src/main/java/anya/pizza/houseki/compat/rei/CrusherCategory.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/CrusherCategory.java
@@ -9,20 +9,21 @@ import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
-import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import java.util.LinkedList;
 import java.util.List;
 
-public class CrusherCategory implements DisplayCategory<BasicDisplay> {
+public class CrusherCategory implements DisplayCategory<CrusherDisplay> {
     public static final Identifier TEXTURE = Identifier.of(Houseki.MOD_ID, "textures/gui/crusher/crusher_gui.png");
     public static final CategoryIdentifier<CrusherDisplay> CRUSHER = CategoryIdentifier.of(Houseki.MOD_ID, "crusher");
 
     @Override
-    public CategoryIdentifier<? extends BasicDisplay> getCategoryIdentifier() {
+    public CategoryIdentifier<CrusherDisplay> getCategoryIdentifier() {
         return CRUSHER;
     }
 
@@ -37,21 +38,31 @@ public class CrusherCategory implements DisplayCategory<BasicDisplay> {
     }
 
     @Override
-    public List<Widget> setupDisplay(BasicDisplay display, Rectangle bounds) {
-        Point startPoint = new Point(bounds.getCenterX() - 87, bounds.getCenterY() - 35);
+    public List<Widget> setupDisplay(CrusherDisplay display, Rectangle bounds) {
+        Point startPoint = new Point(bounds.getCenterX() - 87, bounds.getCenterY() - 41);
         List<Widget> widgets = new LinkedList<>();
 
-        widgets.add(Widgets.createTexturedWidget(TEXTURE, new Rectangle(startPoint.x, startPoint.y, 176, 82)));
+        widgets.add(Widgets.createTexturedWidget(TEXTURE, new Rectangle(startPoint.x, startPoint.y, 176, 84)));
 
         widgets.add(Widgets.createSlot(new Point(startPoint.x + 35, startPoint.y + 5)).entries(display.getInputEntries().get(0)).markInput());
+        // Fuel slot - Iron Ingot (position 13, 41 from screen handler)
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 13, startPoint.y + 41))
+                .entries(EntryIngredient.of(EntryStacks.of(Items.IRON_INGOT))).markInput());
         widgets.add(Widgets.createSlot(new Point(startPoint.x + 116, startPoint.y + 40)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
         widgets.add(Widgets.createArrow(new Point(startPoint.x + 79, startPoint.y + 39)).animationDurationTicks(250));
+
+        if (display.getOutputEntries().size() > 1) {
+            widgets.add(Widgets.createSlot(new Point(startPoint.x + 138, startPoint.y + 40)).entries(display.getOutputEntries().get(1)).disableBackground().markOutput());
+            int chancePercent = (int) Math.round(display.getAuxiliaryChance() * 100);
+            widgets.add(Widgets.createLabel(new Point(startPoint.x + 147, startPoint.y + 62), Text.literal(chancePercent + "%"))
+                    .centered().noShadow().color(0xFF404040, 0xFFBBBBBB));
+        }
 
         return widgets;
     }
 
     @Override
     public int getDisplayHeight() {
-        return 90;
+        return 92;
     }
 }

--- a/src/main/java/anya/pizza/houseki/compat/rei/CrusherCategory.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/CrusherCategory.java
@@ -1,0 +1,57 @@
+package anya.pizza.houseki.compat.rei;
+
+import anya.pizza.houseki.Houseki;
+import anya.pizza.houseki.block.ModBlocks;
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class CrusherCategory implements DisplayCategory<BasicDisplay> {
+    public static final Identifier TEXTURE = Identifier.of(Houseki.MOD_ID, "textures/gui/crusher/crusher_gui.png");
+    public static final CategoryIdentifier<CrusherDisplay> CRUSHER = CategoryIdentifier.of(Houseki.MOD_ID, "crusher");
+
+    @Override
+    public CategoryIdentifier<? extends BasicDisplay> getCategoryIdentifier() {
+        return CRUSHER;
+    }
+
+    @Override
+    public Text getTitle() {
+        return Text.translatable("block.houseki.crusher");
+    }
+
+    @Override
+    public Renderer getIcon() {
+        return EntryStacks.of(ModBlocks.CRUSHER.asItem().getDefaultStack());
+    }
+
+    @Override
+    public List<Widget> setupDisplay(BasicDisplay display, Rectangle bounds) {
+        Point startPoint = new Point(bounds.getCenterX() - 87, bounds.getCenterY() - 35);
+        List<Widget> widgets = new LinkedList<>();
+
+        widgets.add(Widgets.createTexturedWidget(TEXTURE, new Rectangle(startPoint.x, startPoint.y, 176, 82)));
+
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 35, startPoint.y + 5)).entries(display.getInputEntries().get(0)).markInput());
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 116, startPoint.y + 40)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
+        widgets.add(Widgets.createArrow(new Point(startPoint.x + 79, startPoint.y + 39)).animationDurationTicks(250));
+
+        return widgets;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 90;
+    }
+}

--- a/src/main/java/anya/pizza/houseki/compat/rei/CrusherDisplay.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/CrusherDisplay.java
@@ -1,0 +1,56 @@
+package anya.pizza.houseki.compat.rei;
+
+import anya.pizza.houseki.recipe.CrusherRecipe;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.display.DisplaySerializer;
+import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryIngredients;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.recipe.RecipeEntry;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+import java.util.Optional;
+
+public class CrusherDisplay extends BasicDisplay {
+    public static final DisplaySerializer<CrusherDisplay> SERIALIZER = DisplaySerializer.of(
+            RecordCodecBuilder.mapCodec(instance -> instance.group(
+                    EntryIngredient.codec().listOf().fieldOf("inputs").forGetter(CrusherDisplay::getInputEntries),
+                    EntryIngredient.codec().listOf().fieldOf("outputs").forGetter(CrusherDisplay::getOutputEntries),
+                    Identifier.CODEC.optionalFieldOf("location").forGetter(CrusherDisplay::getDisplayLocation)
+            ).apply(instance, CrusherDisplay::new)),
+            PacketCodec.tuple(
+                    EntryIngredient.streamCodec().collect(PacketCodecs.toList()),
+                    CrusherDisplay::getInputEntries,
+                    EntryIngredient.streamCodec().collect(PacketCodecs.toList()),
+                    CrusherDisplay::getOutputEntries,
+                    PacketCodecs.optional(Identifier.PACKET_CODEC),
+                    CrusherDisplay::getDisplayLocation,
+                    CrusherDisplay::new
+            ));
+
+    public CrusherDisplay(RecipeEntry<CrusherRecipe> recipe) {
+        super(List.of(EntryIngredients.ofIngredient(recipe.value().getIngredients().get(0))),
+                List.of(EntryIngredient.of(EntryStacks.of(recipe.value().getResult(null)))),
+                Optional.of(recipe.id().getValue()));
+    }
+
+    public CrusherDisplay(List<EntryIngredient> inputs, List<EntryIngredient> outputs, Optional<Identifier> location) {
+        super(inputs, outputs, location);
+    }
+
+    @Override
+    public CategoryIdentifier<?> getCategoryIdentifier() {
+        return CrusherCategory.CRUSHER;
+    }
+
+    @Override
+    public DisplaySerializer<? extends Display> getSerializer() {
+        return SERIALIZER;
+    }
+}

--- a/src/main/java/anya/pizza/houseki/compat/rei/CrusherDisplay.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/CrusherDisplay.java
@@ -1,6 +1,7 @@
 package anya.pizza.houseki.compat.rei;
 
 import anya.pizza.houseki.recipe.CrusherRecipe;
+import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
@@ -14,15 +15,19 @@ import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.util.Identifier;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 public class CrusherDisplay extends BasicDisplay {
+    private final double auxiliaryChance;
+
     public static final DisplaySerializer<CrusherDisplay> SERIALIZER = DisplaySerializer.of(
             RecordCodecBuilder.mapCodec(instance -> instance.group(
                     EntryIngredient.codec().listOf().fieldOf("inputs").forGetter(CrusherDisplay::getInputEntries),
                     EntryIngredient.codec().listOf().fieldOf("outputs").forGetter(CrusherDisplay::getOutputEntries),
-                    Identifier.CODEC.optionalFieldOf("location").forGetter(CrusherDisplay::getDisplayLocation)
+                    Identifier.CODEC.optionalFieldOf("location").forGetter(CrusherDisplay::getDisplayLocation),
+                    Codec.DOUBLE.optionalFieldOf("auxiliary_chance", 1.0).forGetter(CrusherDisplay::getAuxiliaryChance)
             ).apply(instance, CrusherDisplay::new)),
             PacketCodec.tuple(
                     EntryIngredient.streamCodec().collect(PacketCodecs.toList()),
@@ -31,17 +36,34 @@ public class CrusherDisplay extends BasicDisplay {
                     CrusherDisplay::getOutputEntries,
                     PacketCodecs.optional(Identifier.PACKET_CODEC),
                     CrusherDisplay::getDisplayLocation,
+                    PacketCodecs.DOUBLE,
+                    CrusherDisplay::getAuxiliaryChance,
                     CrusherDisplay::new
             ));
 
     public CrusherDisplay(RecipeEntry<CrusherRecipe> recipe) {
         super(List.of(EntryIngredients.ofIngredient(recipe.value().getIngredients().get(0))),
-                List.of(EntryIngredient.of(EntryStacks.of(recipe.value().getResult(null)))),
+                createOutputs(recipe.value()),
                 Optional.of(recipe.id().getValue()));
+        this.auxiliaryChance = recipe.value().auxiliaryChance();
     }
 
-    public CrusherDisplay(List<EntryIngredient> inputs, List<EntryIngredient> outputs, Optional<Identifier> location) {
+    public CrusherDisplay(List<EntryIngredient> inputs, List<EntryIngredient> outputs, Optional<Identifier> location, double auxiliaryChance) {
         super(inputs, outputs, location);
+        this.auxiliaryChance = auxiliaryChance;
+    }
+
+    private static List<EntryIngredient> createOutputs(CrusherRecipe recipe) {
+        List<EntryIngredient> outputs = new ArrayList<>();
+        outputs.add(EntryIngredient.of(EntryStacks.of(recipe.getResult(null))));
+        if (recipe.auxiliaryOutput().isPresent() && !recipe.auxiliaryOutput().get().isEmpty()) {
+            outputs.add(EntryIngredient.of(EntryStacks.of(recipe.auxiliaryOutput().get())));
+        }
+        return outputs;
+    }
+
+    public double getAuxiliaryChance() {
+        return auxiliaryChance;
     }
 
     @Override

--- a/src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingCategory.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingCategory.java
@@ -10,13 +10,17 @@ import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.item.Items;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 
 import java.util.LinkedList;
 import java.util.List;
 
 public class FoundryCastingCategory implements DisplayCategory<BasicDisplay> {
+    public static final Identifier TEXTURE = Identifier.of(Houseki.MOD_ID, "textures/gui/foundry/foundry_gui.png");
     public static final CategoryIdentifier<FoundryCastingDisplay> FOUNDRY_CASTING =
             CategoryIdentifier.of(Houseki.MOD_ID, "foundry_casting");
 
@@ -37,20 +41,33 @@ public class FoundryCastingCategory implements DisplayCategory<BasicDisplay> {
 
     @Override
     public List<Widget> setupDisplay(BasicDisplay display, Rectangle bounds) {
-        Point startPoint = new Point(bounds.getCenterX() - 41, bounds.getCenterY() - 13);
+        Point startPoint = new Point(bounds.getCenterX() - 87, bounds.getCenterY() - 41);
         List<Widget> widgets = new LinkedList<>();
 
-        widgets.add(Widgets.createRecipeBase(bounds));
-        widgets.add(Widgets.createSlot(new Point(startPoint.x, startPoint.y)).entries(display.getInputEntries().get(0)).markInput());
-        widgets.add(Widgets.createArrow(new Point(startPoint.x + 24, startPoint.y)).animationDurationTicks(200));
-        widgets.add(Widgets.createResultSlotBackground(new Point(startPoint.x + 61, startPoint.y)));
-        widgets.add(Widgets.createSlot(new Point(startPoint.x + 61, startPoint.y)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
+        widgets.add(Widgets.createTexturedWidget(TEXTURE, new Rectangle(startPoint.x, startPoint.y, 176, 84)));
+
+        // Metal ingot input (melting input slot position)
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 26, startPoint.y + 18))
+                .entries(display.getInputEntries().get(0)).markInput());
+        // Fuel slot - Coal (position 26, 53 from screen handler)
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 26, startPoint.y + 53))
+                .entries(EntryIngredient.of(EntryStacks.of(Items.COAL))).markInput());
+        // Melt arrow
+        widgets.add(Widgets.createArrow(new Point(startPoint.x + 49, startPoint.y + 35)).animationDurationTicks(200));
+        // Cast mold input (cast slot position)
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 134, startPoint.y + 18))
+                .entries(display.getInputEntries().size() > 1 ? display.getInputEntries().get(1) : display.getInputEntries().get(0)).markInput());
+        // Cast arrow
+        widgets.add(Widgets.createArrow(new Point(startPoint.x + 102, startPoint.y + 35)).animationDurationTicks(200));
+        // Output (output slot position)
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 135, startPoint.y + 53))
+                .entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
 
         return widgets;
     }
 
     @Override
     public int getDisplayHeight() {
-        return 36;
+        return 92;
     }
 }

--- a/src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingCategory.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingCategory.java
@@ -1,0 +1,56 @@
+package anya.pizza.houseki.compat.rei;
+
+import anya.pizza.houseki.Houseki;
+import anya.pizza.houseki.block.ModBlocks;
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.text.Text;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class FoundryCastingCategory implements DisplayCategory<BasicDisplay> {
+    public static final CategoryIdentifier<FoundryCastingDisplay> FOUNDRY_CASTING =
+            CategoryIdentifier.of(Houseki.MOD_ID, "foundry_casting");
+
+    @Override
+    public CategoryIdentifier<? extends BasicDisplay> getCategoryIdentifier() {
+        return FOUNDRY_CASTING;
+    }
+
+    @Override
+    public Text getTitle() {
+        return Text.translatable("category.houseki.foundry_casting");
+    }
+
+    @Override
+    public Renderer getIcon() {
+        return EntryStacks.of(ModBlocks.FOUNDRY.asItem().getDefaultStack());
+    }
+
+    @Override
+    public List<Widget> setupDisplay(BasicDisplay display, Rectangle bounds) {
+        Point startPoint = new Point(bounds.getCenterX() - 41, bounds.getCenterY() - 13);
+        List<Widget> widgets = new LinkedList<>();
+
+        widgets.add(Widgets.createRecipeBase(bounds));
+        widgets.add(Widgets.createSlot(new Point(startPoint.x, startPoint.y)).entries(display.getInputEntries().get(0)).markInput());
+        widgets.add(Widgets.createArrow(new Point(startPoint.x + 24, startPoint.y)).animationDurationTicks(200));
+        widgets.add(Widgets.createResultSlotBackground(new Point(startPoint.x + 61, startPoint.y)));
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 61, startPoint.y)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
+
+        return widgets;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 36;
+    }
+}

--- a/src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingDisplay.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingDisplay.java
@@ -1,0 +1,56 @@
+package anya.pizza.houseki.compat.rei;
+
+import anya.pizza.houseki.recipe.FoundryCastingRecipe;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.display.DisplaySerializer;
+import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryIngredients;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.recipe.RecipeEntry;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+import java.util.Optional;
+
+public class FoundryCastingDisplay extends BasicDisplay {
+    public static final DisplaySerializer<FoundryCastingDisplay> SERIALIZER = DisplaySerializer.of(
+            RecordCodecBuilder.mapCodec(instance -> instance.group(
+                    EntryIngredient.codec().listOf().fieldOf("inputs").forGetter(FoundryCastingDisplay::getInputEntries),
+                    EntryIngredient.codec().listOf().fieldOf("outputs").forGetter(FoundryCastingDisplay::getOutputEntries),
+                    Identifier.CODEC.optionalFieldOf("location").forGetter(FoundryCastingDisplay::getDisplayLocation)
+            ).apply(instance, FoundryCastingDisplay::new)),
+            PacketCodec.tuple(
+                    EntryIngredient.streamCodec().collect(PacketCodecs.toList()),
+                    FoundryCastingDisplay::getInputEntries,
+                    EntryIngredient.streamCodec().collect(PacketCodecs.toList()),
+                    FoundryCastingDisplay::getOutputEntries,
+                    PacketCodecs.optional(Identifier.PACKET_CODEC),
+                    FoundryCastingDisplay::getDisplayLocation,
+                    FoundryCastingDisplay::new
+            ));
+
+    public FoundryCastingDisplay(RecipeEntry<FoundryCastingRecipe> recipe) {
+        super(List.of(EntryIngredients.ofIngredient(recipe.value().inputCastingItem())),
+                List.of(EntryIngredient.of(EntryStacks.of(recipe.value().output()))),
+                Optional.of(recipe.id().getValue()));
+    }
+
+    public FoundryCastingDisplay(List<EntryIngredient> inputs, List<EntryIngredient> outputs, Optional<Identifier> location) {
+        super(inputs, outputs, location);
+    }
+
+    @Override
+    public CategoryIdentifier<?> getCategoryIdentifier() {
+        return FoundryCastingCategory.FOUNDRY_CASTING;
+    }
+
+    @Override
+    public DisplaySerializer<? extends Display> getSerializer() {
+        return SERIALIZER;
+    }
+}

--- a/src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingCategory.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingCategory.java
@@ -1,0 +1,56 @@
+package anya.pizza.houseki.compat.rei;
+
+import anya.pizza.houseki.Houseki;
+import anya.pizza.houseki.block.ModBlocks;
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.text.Text;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class FoundryMeltingCategory implements DisplayCategory<BasicDisplay> {
+    public static final CategoryIdentifier<FoundryMeltingDisplay> FOUNDRY_MELTING =
+            CategoryIdentifier.of(Houseki.MOD_ID, "foundry_melting");
+
+    @Override
+    public CategoryIdentifier<? extends BasicDisplay> getCategoryIdentifier() {
+        return FOUNDRY_MELTING;
+    }
+
+    @Override
+    public Text getTitle() {
+        return Text.translatable("category.houseki.foundry_melting");
+    }
+
+    @Override
+    public Renderer getIcon() {
+        return EntryStacks.of(ModBlocks.FOUNDRY.asItem().getDefaultStack());
+    }
+
+    @Override
+    public List<Widget> setupDisplay(BasicDisplay display, Rectangle bounds) {
+        Point startPoint = new Point(bounds.getCenterX() - 41, bounds.getCenterY() - 13);
+        List<Widget> widgets = new LinkedList<>();
+
+        widgets.add(Widgets.createRecipeBase(bounds));
+        widgets.add(Widgets.createSlot(new Point(startPoint.x, startPoint.y)).entries(display.getInputEntries().get(0)).markInput());
+        widgets.add(Widgets.createArrow(new Point(startPoint.x + 24, startPoint.y)).animationDurationTicks(200));
+        widgets.add(Widgets.createResultSlotBackground(new Point(startPoint.x + 61, startPoint.y)));
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 61, startPoint.y)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
+
+        return widgets;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 36;
+    }
+}

--- a/src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingCategory.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingCategory.java
@@ -10,13 +10,17 @@ import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.item.Items;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 
 import java.util.LinkedList;
 import java.util.List;
 
 public class FoundryMeltingCategory implements DisplayCategory<BasicDisplay> {
+    public static final Identifier TEXTURE = Identifier.of(Houseki.MOD_ID, "textures/gui/foundry/foundry_gui.png");
     public static final CategoryIdentifier<FoundryMeltingDisplay> FOUNDRY_MELTING =
             CategoryIdentifier.of(Houseki.MOD_ID, "foundry_melting");
 
@@ -37,20 +41,28 @@ public class FoundryMeltingCategory implements DisplayCategory<BasicDisplay> {
 
     @Override
     public List<Widget> setupDisplay(BasicDisplay display, Rectangle bounds) {
-        Point startPoint = new Point(bounds.getCenterX() - 41, bounds.getCenterY() - 13);
+        Point startPoint = new Point(bounds.getCenterX() - 87, bounds.getCenterY() - 41);
         List<Widget> widgets = new LinkedList<>();
 
-        widgets.add(Widgets.createRecipeBase(bounds));
-        widgets.add(Widgets.createSlot(new Point(startPoint.x, startPoint.y)).entries(display.getInputEntries().get(0)).markInput());
-        widgets.add(Widgets.createArrow(new Point(startPoint.x + 24, startPoint.y)).animationDurationTicks(200));
-        widgets.add(Widgets.createResultSlotBackground(new Point(startPoint.x + 61, startPoint.y)));
-        widgets.add(Widgets.createSlot(new Point(startPoint.x + 61, startPoint.y)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
+        widgets.add(Widgets.createTexturedWidget(TEXTURE, new Rectangle(startPoint.x, startPoint.y, 176, 84)));
+
+        // Input slot (melt input position)
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 26, startPoint.y + 18))
+                .entries(display.getInputEntries().get(0)).markInput());
+        // Fuel slot - Coal (position 26, 53 from screen handler)
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 26, startPoint.y + 53))
+                .entries(EntryIngredient.of(EntryStacks.of(Items.COAL))).markInput());
+        // Melt arrow
+        widgets.add(Widgets.createArrow(new Point(startPoint.x + 49, startPoint.y + 35)).animationDurationTicks(200));
+        // Output shown in the output slot area
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 135, startPoint.y + 53))
+                .entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
 
         return widgets;
     }
 
     @Override
     public int getDisplayHeight() {
-        return 36;
+        return 92;
     }
 }

--- a/src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingDisplay.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingDisplay.java
@@ -1,0 +1,56 @@
+package anya.pizza.houseki.compat.rei;
+
+import anya.pizza.houseki.recipe.FoundryMeltingRecipe;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.display.DisplaySerializer;
+import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryIngredients;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.recipe.RecipeEntry;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+import java.util.Optional;
+
+public class FoundryMeltingDisplay extends BasicDisplay {
+    public static final DisplaySerializer<FoundryMeltingDisplay> SERIALIZER = DisplaySerializer.of(
+            RecordCodecBuilder.mapCodec(instance -> instance.group(
+                    EntryIngredient.codec().listOf().fieldOf("inputs").forGetter(FoundryMeltingDisplay::getInputEntries),
+                    EntryIngredient.codec().listOf().fieldOf("outputs").forGetter(FoundryMeltingDisplay::getOutputEntries),
+                    Identifier.CODEC.optionalFieldOf("location").forGetter(FoundryMeltingDisplay::getDisplayLocation)
+            ).apply(instance, FoundryMeltingDisplay::new)),
+            PacketCodec.tuple(
+                    EntryIngredient.streamCodec().collect(PacketCodecs.toList()),
+                    FoundryMeltingDisplay::getInputEntries,
+                    EntryIngredient.streamCodec().collect(PacketCodecs.toList()),
+                    FoundryMeltingDisplay::getOutputEntries,
+                    PacketCodecs.optional(Identifier.PACKET_CODEC),
+                    FoundryMeltingDisplay::getDisplayLocation,
+                    FoundryMeltingDisplay::new
+            ));
+
+    public FoundryMeltingDisplay(RecipeEntry<FoundryMeltingRecipe> recipe) {
+        super(List.of(EntryIngredients.ofIngredient(recipe.value().inputMeltingItem())),
+                List.of(EntryIngredient.of(EntryStacks.of(recipe.value().output()))),
+                Optional.of(recipe.id().getValue()));
+    }
+
+    public FoundryMeltingDisplay(List<EntryIngredient> inputs, List<EntryIngredient> outputs, Optional<Identifier> location) {
+        super(inputs, outputs, location);
+    }
+
+    @Override
+    public CategoryIdentifier<?> getCategoryIdentifier() {
+        return FoundryMeltingCategory.FOUNDRY_MELTING;
+    }
+
+    @Override
+    public DisplaySerializer<? extends Display> getSerializer() {
+        return SERIALIZER;
+    }
+}

--- a/src/main/java/anya/pizza/houseki/compat/rei/HousekiREIClient.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/HousekiREIClient.java
@@ -2,6 +2,7 @@ package anya.pizza.houseki.compat.rei;
 
 import anya.pizza.houseki.block.ModBlocks;
 import anya.pizza.houseki.screen.custom.CrusherScreen;
+import anya.pizza.houseki.screen.custom.FoundryScreen;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
@@ -13,11 +14,21 @@ public class HousekiREIClient implements REIClientPlugin {
     public void registerCategories(CategoryRegistry registry) {
         registry.add(new CrusherCategory());
         registry.addWorkstations(CrusherCategory.CRUSHER, EntryStacks.of(ModBlocks.CRUSHER));
+
+        registry.add(new FoundryMeltingCategory());
+        registry.addWorkstations(FoundryMeltingCategory.FOUNDRY_MELTING, EntryStacks.of(ModBlocks.FOUNDRY));
+
+        registry.add(new FoundryCastingCategory());
+        registry.addWorkstations(FoundryCastingCategory.FOUNDRY_CASTING, EntryStacks.of(ModBlocks.FOUNDRY));
     }
 
     @Override
     public void registerScreens(ScreenRegistry registry) {
         registry.registerClickArea(screen -> new Rectangle(((screen.width - 176) / 2) + 78, ((screen.height - 176) / 2) + 30, 20, 25),
                 CrusherScreen.class, CrusherCategory.CRUSHER);
+        registry.registerClickArea(screen -> new Rectangle(((screen.width - 176) / 2) + 49, ((screen.height - 176) / 2) + 35, 24, 16),
+                FoundryScreen.class, FoundryMeltingCategory.FOUNDRY_MELTING);
+        registry.registerClickArea(screen -> new Rectangle(((screen.width - 176) / 2) + 102, ((screen.height - 176) / 2) + 35, 24, 16),
+                FoundryScreen.class, FoundryCastingCategory.FOUNDRY_CASTING);
     }
 }

--- a/src/main/java/anya/pizza/houseki/compat/rei/HousekiREIClient.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/HousekiREIClient.java
@@ -1,0 +1,23 @@
+package anya.pizza.houseki.compat.rei;
+
+import anya.pizza.houseki.block.ModBlocks;
+import anya.pizza.houseki.screen.custom.CrusherScreen;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
+import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
+import me.shedaniel.rei.api.client.registry.screen.ScreenRegistry;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+
+public class HousekiREIClient implements REIClientPlugin {
+    @Override
+    public void registerCategories(CategoryRegistry registry) {
+        registry.add(new CrusherCategory());
+        registry.addWorkstations(CrusherCategory.CRUSHER, EntryStacks.of(ModBlocks.CRUSHER));
+    }
+
+    @Override
+    public void registerScreens(ScreenRegistry registry) {
+        registry.registerClickArea(screen -> new Rectangle(((screen.width - 176) / 2) + 78, ((screen.height - 176) / 2) + 30, 20, 25),
+                CrusherScreen.class, CrusherCategory.CRUSHER);
+    }
+}

--- a/src/main/java/anya/pizza/houseki/compat/rei/HousekiREIClient.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/HousekiREIClient.java
@@ -2,12 +2,19 @@ package anya.pizza.houseki.compat.rei;
 
 import anya.pizza.houseki.block.ModBlocks;
 import anya.pizza.houseki.screen.custom.CrusherScreen;
+import anya.pizza.houseki.screen.custom.CrusherScreenHandler;
 import anya.pizza.houseki.screen.custom.FoundryScreen;
+import anya.pizza.houseki.screen.custom.FoundryScreenHandler;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.screen.ScreenRegistry;
+import me.shedaniel.rei.api.client.registry.transfer.TransferHandlerRegistry;
+import me.shedaniel.rei.api.client.registry.transfer.simple.SimpleTransferHandler;
+import me.shedaniel.rei.api.common.transfer.info.stack.SlotAccessor;
 import me.shedaniel.rei.api.common.util.EntryStacks;
+
+import java.util.List;
 
 public class HousekiREIClient implements REIClientPlugin {
     @Override
@@ -30,5 +37,53 @@ public class HousekiREIClient implements REIClientPlugin {
                 FoundryScreen.class, FoundryMeltingCategory.FOUNDRY_MELTING);
         registry.registerClickArea(screen -> new Rectangle(((screen.width - 176) / 2) + 102, ((screen.height - 176) / 2) + 35, 24, 16),
                 FoundryScreen.class, FoundryCastingCategory.FOUNDRY_CASTING);
+    }
+
+    @Override
+    public void registerTransferHandlers(TransferHandlerRegistry registry) {
+        // Crusher: input slot 0, player inventory slots 4-39
+        registry.register(SimpleTransferHandler.create(
+                CrusherScreenHandler.class,
+                CrusherCategory.CRUSHER,
+                new SimpleTransferHandler.IntRange(0, 1)
+        ));
+
+        // Foundry melting: input slot 0, player inventory slots 5-40
+        registry.register(SimpleTransferHandler.create(
+                FoundryScreenHandler.class,
+                FoundryMeltingCategory.FOUNDRY_MELTING,
+                new SimpleTransferHandler.IntRange(0, 1)
+        ));
+
+        // Foundry casting: metal goes to slot 0, cast goes to slot 2 (non-contiguous)
+        registry.register(new SimpleTransferHandler() {
+            @Override
+            public ApplicabilityResult checkApplicable(Context context) {
+                if (context.getMenu() instanceof FoundryScreenHandler
+                        && context.getDisplay().getCategoryIdentifier().equals(FoundryCastingCategory.FOUNDRY_CASTING)) {
+                    return ApplicabilityResult.createApplicable();
+                }
+                return ApplicabilityResult.createNotApplicable();
+            }
+
+            @Override
+            public Iterable<SlotAccessor> getInputSlots(Context context) {
+                var menu = context.getMenu();
+                return List.of(
+                        SlotAccessor.fromSlot(menu.slots.get(0)),  // metal input slot
+                        SlotAccessor.fromSlot(menu.slots.get(2))   // cast mold slot
+                );
+            }
+
+            @Override
+            public Iterable<SlotAccessor> getInventorySlots(Context context) {
+                var menu = context.getMenu();
+                var slots = new java.util.ArrayList<SlotAccessor>();
+                for (int i = 5; i < menu.slots.size(); i++) {
+                    slots.add(SlotAccessor.fromSlot(menu.slots.get(i)));
+                }
+                return slots;
+            }
+        });
     }
 }

--- a/src/main/java/anya/pizza/houseki/compat/rei/HousekiREICommon.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/HousekiREICommon.java
@@ -1,14 +1,19 @@
 package anya.pizza.houseki.compat.rei;
 
 import anya.pizza.houseki.Houseki;
+import anya.pizza.houseki.item.ModItems;
 import anya.pizza.houseki.recipe.CrusherRecipe;
-import anya.pizza.houseki.recipe.FoundryCastingRecipe;
-import anya.pizza.houseki.recipe.FoundryMeltingRecipe;
 import anya.pizza.houseki.recipe.ModRecipes;
 import me.shedaniel.rei.api.common.display.DisplaySerializerRegistry;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.plugins.REICommonPlugin;
 import me.shedaniel.rei.api.common.registry.display.ServerDisplayRegistry;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.item.Item;
 import net.minecraft.util.Identifier;
+
+import java.util.List;
+import java.util.Optional;
 
 public class HousekiREICommon implements REICommonPlugin {
     @Override
@@ -16,12 +21,43 @@ public class HousekiREICommon implements REICommonPlugin {
         registry.beginRecipeFiller(CrusherRecipe.class)
                 .filterType(ModRecipes.CRUSHER_TYPE)
                 .fill(entry -> new CrusherDisplay(entry));
-        registry.beginRecipeFiller(FoundryMeltingRecipe.class)
-                .filterType(ModRecipes.FOUNDRY_MELTING_TYPE)
-                .fill(entry -> new FoundryMeltingDisplay(entry));
-        registry.beginRecipeFiller(FoundryCastingRecipe.class)
-                .filterType(ModRecipes.FOUNDRY_CASTING_TYPE)
-                .fill(entry -> new FoundryCastingDisplay(entry));
+
+        registerCastingDisplays(registry);
+    }
+
+    private void registerCastingDisplays(ServerDisplayRegistry registry) {
+        // Steel casting recipes
+        addCasting(registry, ModItems.STEEL, ModItems.INGOT_CAST, ModItems.CAST_STEEL);
+        addCasting(registry, ModItems.STEEL, ModItems.PICKAXE_HEAD_CAST, ModItems.CS_PICKAXE_HEAD);
+        addCasting(registry, ModItems.STEEL, ModItems.AXE_HEAD_CAST, ModItems.CS_AXE_HEAD);
+        addCasting(registry, ModItems.STEEL, ModItems.SHOVEL_HEAD_CAST, ModItems.CS_SHOVEL_HEAD);
+        addCasting(registry, ModItems.STEEL, ModItems.SWORD_HEAD_CAST, ModItems.CS_SWORD_HEAD);
+        addCasting(registry, ModItems.STEEL, ModItems.HOE_HEAD_CAST, ModItems.CS_HOE_HEAD);
+        addCasting(registry, ModItems.STEEL, ModItems.SPEAR_HEAD_CAST, ModItems.CS_SPEAR_HEAD);
+        addCasting(registry, ModItems.STEEL, ModItems.HELMET_CAST, ModItems.CAST_STEEL_HELMET);
+        addCasting(registry, ModItems.STEEL, ModItems.CHESTPLATE_CAST, ModItems.CAST_STEEL_CHESTPLATE);
+        addCasting(registry, ModItems.STEEL, ModItems.LEGGINGS_CAST, ModItems.CAST_STEEL_LEGGINGS);
+        addCasting(registry, ModItems.STEEL, ModItems.BOOTS_CAST, ModItems.CAST_STEEL_BOOTS);
+
+        // Meteoric Iron casting recipes
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.INGOT_CAST, ModItems.METEORIC_IRON_INGOT);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.PICKAXE_HEAD_CAST, ModItems.MI_PICKAXE_HEAD);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.AXE_HEAD_CAST, ModItems.MI_AXE_HEAD);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.SHOVEL_HEAD_CAST, ModItems.MI_SHOVEL_HEAD);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.SWORD_HEAD_CAST, ModItems.MI_SWORD_HEAD);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.HOE_HEAD_CAST, ModItems.MI_HOE_HEAD);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.SPEAR_HEAD_CAST, ModItems.MI_SPEAR_HEAD);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.HELMET_CAST, ModItems.METEORIC_IRON_HELMET);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.CHESTPLATE_CAST, ModItems.METEORIC_IRON_CHESTPLATE);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.LEGGINGS_CAST, ModItems.METEORIC_IRON_LEGGINGS);
+        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.BOOTS_CAST, ModItems.METEORIC_IRON_BOOTS);
+    }
+
+    private void addCasting(ServerDisplayRegistry registry, Item metal, Item cast, Item result) {
+        registry.add(new FoundryCastingDisplay(
+                List.of(EntryIngredient.of(EntryStacks.of(metal)), EntryIngredient.of(EntryStacks.of(cast))),
+                List.of(EntryIngredient.of(EntryStacks.of(result))),
+                Optional.empty()));
     }
 
     @Override

--- a/src/main/java/anya/pizza/houseki/compat/rei/HousekiREICommon.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/HousekiREICommon.java
@@ -1,0 +1,23 @@
+package anya.pizza.houseki.compat.rei;
+
+import anya.pizza.houseki.Houseki;
+import anya.pizza.houseki.recipe.CrusherRecipe;
+import anya.pizza.houseki.recipe.ModRecipes;
+import me.shedaniel.rei.api.common.display.DisplaySerializerRegistry;
+import me.shedaniel.rei.api.common.plugins.REICommonPlugin;
+import me.shedaniel.rei.api.common.registry.display.ServerDisplayRegistry;
+import net.minecraft.util.Identifier;
+
+public class HousekiREICommon implements REICommonPlugin {
+    @Override
+    public void registerDisplays(ServerDisplayRegistry registry) {
+        registry.beginRecipeFiller(CrusherRecipe.class)
+                .filterType(ModRecipes.CRUSHER_TYPE)
+                .fill(entry -> new CrusherDisplay(entry));
+    }
+
+    @Override
+    public void registerDisplaySerializer(DisplaySerializerRegistry registry) {
+        registry.register(Identifier.of(Houseki.MOD_ID, "crusher"), CrusherDisplay.SERIALIZER);
+    }
+}

--- a/src/main/java/anya/pizza/houseki/compat/rei/HousekiREICommon.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/HousekiREICommon.java
@@ -2,6 +2,8 @@ package anya.pizza.houseki.compat.rei;
 
 import anya.pizza.houseki.Houseki;
 import anya.pizza.houseki.recipe.CrusherRecipe;
+import anya.pizza.houseki.recipe.FoundryCastingRecipe;
+import anya.pizza.houseki.recipe.FoundryMeltingRecipe;
 import anya.pizza.houseki.recipe.ModRecipes;
 import me.shedaniel.rei.api.common.display.DisplaySerializerRegistry;
 import me.shedaniel.rei.api.common.plugins.REICommonPlugin;
@@ -14,10 +16,18 @@ public class HousekiREICommon implements REICommonPlugin {
         registry.beginRecipeFiller(CrusherRecipe.class)
                 .filterType(ModRecipes.CRUSHER_TYPE)
                 .fill(entry -> new CrusherDisplay(entry));
+        registry.beginRecipeFiller(FoundryMeltingRecipe.class)
+                .filterType(ModRecipes.FOUNDRY_MELTING_TYPE)
+                .fill(entry -> new FoundryMeltingDisplay(entry));
+        registry.beginRecipeFiller(FoundryCastingRecipe.class)
+                .filterType(ModRecipes.FOUNDRY_CASTING_TYPE)
+                .fill(entry -> new FoundryCastingDisplay(entry));
     }
 
     @Override
     public void registerDisplaySerializer(DisplaySerializerRegistry registry) {
         registry.register(Identifier.of(Houseki.MOD_ID, "crusher"), CrusherDisplay.SERIALIZER);
+        registry.register(Identifier.of(Houseki.MOD_ID, "foundry_melting"), FoundryMeltingDisplay.SERIALIZER);
+        registry.register(Identifier.of(Houseki.MOD_ID, "foundry_casting"), FoundryCastingDisplay.SERIALIZER);
     }
 }

--- a/src/main/resources/assets/houseki/lang/en_us.json
+++ b/src/main/resources/assets/houseki/lang/en_us.json
@@ -339,5 +339,8 @@
   "advancements.houseki.foundry_crafting.title": "Melting and Casting",
   "advancements.houseki.foundry_crafting.description": "Crafted a Foundry!",
   "advancements.houseki.meteorite.title": "Space Rock",
-  "advancements.houseki.meteorite.description": "Found a Meteorite!"
+  "advancements.houseki.meteorite.description": "Found a Meteorite!",
+
+  "category.houseki.foundry_melting": "Foundry Melting",
+  "category.houseki.foundry_casting": "Foundry Casting"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,12 @@
 		],
 		"client": [
 			"anya.pizza.houseki.HousekiClient"
+		],
+		"rei_client": [
+			"anya.pizza.houseki.compat.rei.HousekiREIClient"
+		],
+		"rei_common": [
+			"anya.pizza.houseki.compat.rei.HousekiREICommon"
 		]
 	},
 	"mixins": [
@@ -39,7 +45,8 @@
 		"fabric-api": "*"
 	},
 	"suggests": {
-		"modmenu": ">=17.0.0-beta.2"
+		"modmenu": ">=17.0.0-beta.2",
+		"rei": ">=21.11.814"
 	},
 	"custom": {
 		"modmenu": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **REI Compatibility for Crusher**: Added `CrusherDisplay` and `CrusherCategory` with GUI texture rendering, slot layout, and animated progress indicators. Includes server-client synchronization for recipes via `DisplaySerializer`.
- **REI Compatibility for Foundry**: Implemented `FoundryMeltingDisplay`/`FoundryMeltingCategory` and `FoundryCastingDisplay`/`FoundryCastingCategory` with proper widget layouts and animations.
- **REI Plugin Registration**: Added `HousekiREIClient` plugin for category registration, screen integration, and transfer handlers; added `HousekiREICommon` plugin for recipe display registration and serializer mapping.
- **New Dependencies**: Added REI 21.11.814, Architectury 19.0.1, and Cloth Config 21.11.153.
- **Translation Keys**: Added `category.houseki.foundry_melting` and `category.houseki.foundry_casting` entries.
- **Bug Fix**: Used record accessors directly to avoid `FoundryCastingRecipe.getIngredients()` issue.
- **Manifest Updates**: Registered `rei_client` and `rei_common` entrypoints in `fabric.mod.json` and added optional REI dependency suggestion.

## Contribution Summary

| File | Added | Removed | Author |
|------|-------|---------|--------|
| build.gradle | 8 | 0 | shaedy180 |
| gradle.properties | 4 | 1 | shaedy180 |
| src/main/java/anya/pizza/houseki/compat/rei/CrusherCategory.java | 68 | 0 | shaedy180 |
| src/main/java/anya/pizza/houseki/compat/rei/CrusherDisplay.java | 78 | 0 | shaedy180 |
| src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingCategory.java | 73 | 0 | shaedy180 |
| src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingDisplay.java | 56 | 0 | shaedy180 |
| src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingCategory.java | 68 | 0 | shaedy180 |
| src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingDisplay.java | 56 | 0 | shaedy180 |
| src/main/java/anya/pizza/houseki/compat/rei/HousekiREIClient.java | 89 | 0 | shaedy180 |
| src/main/java/anya/pizza/houseki/compat/rei/HousekiREICommon.java | 69 | 0 | shaedy180 |
| src/main/resources/assets/houseki/lang/en_us.json | 4 | 1 | shaedy180 |
| src/main/resources/fabric.mod.json | 8 | 1 | shaedy180 |
| **TOTAL** | **581** | **3** | shaedy180 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->