### PR TITLE
Fix REI integration issues from PR #42 review

### DIFF
--- a/src/main/java/anya/pizza/houseki/compat/rei/CrusherCategory.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/CrusherCategory.java
@@ -47,7 +47,7 @@ public class CrusherCategory implements DisplayCategory<CrusherDisplay> {
         widgets.add(Widgets.createSlot(new Point(startPoint.x + 35, startPoint.y + 5)).entries(display.getInputEntries().get(0)).markInput());
         // Fuel slot - Iron Ingot (position 13, 41 from screen handler)
         widgets.add(Widgets.createSlot(new Point(startPoint.x + 13, startPoint.y + 51))
-                .entries(EntryIngredient.of(EntryStacks.of(Items.IRON_INGOT))).markInput());
+                .entries(EntryIngredient.of(EntryStacks.of(Items.IRON_INGOT))));
         widgets.add(Widgets.createSlot(new Point(startPoint.x + 116, startPoint.y + 40)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
         widgets.add(Widgets.createArrow(new Point(startPoint.x + 79, startPoint.y + 39)).animationDurationTicks(250));
 
@@ -64,5 +64,10 @@ public class CrusherCategory implements DisplayCategory<CrusherDisplay> {
     @Override
     public int getDisplayHeight() {
         return 92;
+    }
+
+    @Override
+    public int getDisplayWidth(CrusherDisplay display) {
+        return 176;
     }
 }

--- a/src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingCategory.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/FoundryCastingCategory.java
@@ -51,7 +51,7 @@ public class FoundryCastingCategory implements DisplayCategory<BasicDisplay> {
                 .entries(display.getInputEntries().get(0)).markInput());
         // Fuel slot - Coal (position 26, 53 from screen handler)
         widgets.add(Widgets.createSlot(new Point(startPoint.x + 26, startPoint.y + 53))
-                .entries(EntryIngredient.of(EntryStacks.of(Items.COAL))).markInput());
+                .entries(EntryIngredient.of(EntryStacks.of(Items.COAL))));
         // Melt arrow
         widgets.add(Widgets.createArrow(new Point(startPoint.x + 49, startPoint.y + 35)).animationDurationTicks(200));
         // Cast mold input (cast slot position)
@@ -69,5 +69,10 @@ public class FoundryCastingCategory implements DisplayCategory<BasicDisplay> {
     @Override
     public int getDisplayHeight() {
         return 92;
+    }
+
+    @Override
+    public int getDisplayWidth(BasicDisplay display) {
+        return 176;
     }
 }

--- a/src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingCategory.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/FoundryMeltingCategory.java
@@ -51,7 +51,7 @@ public class FoundryMeltingCategory implements DisplayCategory<BasicDisplay> {
                 .entries(display.getInputEntries().get(0)).markInput());
         // Fuel slot - Coal (position 26, 53 from screen handler)
         widgets.add(Widgets.createSlot(new Point(startPoint.x + 26, startPoint.y + 53))
-                .entries(EntryIngredient.of(EntryStacks.of(Items.COAL))).markInput());
+                .entries(EntryIngredient.of(EntryStacks.of(Items.COAL))));
         // Melt arrow
         widgets.add(Widgets.createArrow(new Point(startPoint.x + 49, startPoint.y + 35)).animationDurationTicks(200));
         // Output shown in the output slot area
@@ -64,5 +64,10 @@ public class FoundryMeltingCategory implements DisplayCategory<BasicDisplay> {
     @Override
     public int getDisplayHeight() {
         return 92;
+    }
+
+    @Override
+    public int getDisplayWidth(BasicDisplay display) {
+        return 176;
     }
 }

--- a/src/main/java/anya/pizza/houseki/compat/rei/HousekiREIClient.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/HousekiREIClient.java
@@ -59,7 +59,8 @@ public class HousekiREIClient implements REIClientPlugin {
         registry.register(new SimpleTransferHandler() {
             @Override
             public ApplicabilityResult checkApplicable(Context context) {
-                if (context.getMenu() instanceof FoundryScreenHandler
+                if (context.getContainerScreen() != null
+                        && context.getMenu() instanceof FoundryScreenHandler
                         && context.getDisplay().getCategoryIdentifier().equals(FoundryCastingCategory.FOUNDRY_CASTING)) {
                     return ApplicabilityResult.createApplicable();
                 }

--- a/src/main/java/anya/pizza/houseki/compat/rei/HousekiREICommon.java
+++ b/src/main/java/anya/pizza/houseki/compat/rei/HousekiREICommon.java
@@ -3,6 +3,7 @@ package anya.pizza.houseki.compat.rei;
 import anya.pizza.houseki.Houseki;
 import anya.pizza.houseki.item.ModItems;
 import anya.pizza.houseki.recipe.CrusherRecipe;
+import anya.pizza.houseki.recipe.FoundryMeltingRecipe;
 import anya.pizza.houseki.recipe.ModRecipes;
 import me.shedaniel.rei.api.common.display.DisplaySerializerRegistry;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
@@ -20,7 +21,11 @@ public class HousekiREICommon implements REICommonPlugin {
     public void registerDisplays(ServerDisplayRegistry registry) {
         registry.beginRecipeFiller(CrusherRecipe.class)
                 .filterType(ModRecipes.CRUSHER_TYPE)
-                .fill(entry -> new CrusherDisplay(entry));
+                .fill(CrusherDisplay::new);
+
+        registry.beginRecipeFiller(FoundryMeltingRecipe.class)
+                .filterType(ModRecipes.FOUNDRY_MELTING_TYPE)
+                .fill(FoundryMeltingDisplay::new);
 
         registerCastingDisplays(registry);
     }
@@ -40,7 +45,6 @@ public class HousekiREICommon implements REICommonPlugin {
         addCasting(registry, ModItems.STEEL, ModItems.BOOTS_CAST, ModItems.CAST_STEEL_BOOTS);
 
         // Meteoric Iron casting recipes
-        addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.INGOT_CAST, ModItems.METEORIC_IRON_INGOT);
         addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.PICKAXE_HEAD_CAST, ModItems.MI_PICKAXE_HEAD);
         addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.AXE_HEAD_CAST, ModItems.MI_AXE_HEAD);
         addCasting(registry, ModItems.METEORIC_IRON_INGOT, ModItems.SHOVEL_HEAD_CAST, ModItems.MI_SHOVEL_HEAD);


### PR DESCRIPTION
- Add getDisplayWidth() override (176px) to CrusherCategory, FoundryMeltingCategory, and FoundryCastingCategory to match the 176px texture layout (REI default is 150px)
- Remove .markInput() from hardcoded fuel display slots (iron ingot in CrusherCategory, coal in both Foundry categories) to fix SimpleTransferHandler input index alignment
- Add null-screen guard in custom FoundryCasting transfer handler to prevent potential NPE when container screen is absent
- Register FoundryMeltingRecipe displays in HousekiREICommon so melting recipes actually appear in REI
- Use method reference CrusherDisplay::new instead of lambda
- Remove bogus METEORIC_IRON_INGOT + INGOT_CAST recipe where input equals output (no CAST_METEORIC_IRON item exists)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Override `getDisplayWidth()` to return 176px in CrusherCategory, FoundryMeltingCategory, and FoundryCastingCategory to properly align with 176px texture layouts
- Remove `.markInput()` calls from hardcoded fuel display slots (iron ingot in CrusherCategory; coal in both Foundry categories) to correct SimpleTransferHandler input index alignment
- Add null-screen guard (`context.getContainerScreen() != null`) in the FoundryCasting transfer handler to prevent NullPointerException when container screen is absent
- Register FoundryMeltingRecipe displays in HousekiREICommon to make melting recipes visible in REI
- Replace lambda with method reference (`CrusherDisplay::new`) in Crusher recipe filler
- Remove invalid recipe pairing (METEORIC_IRON_INGOT + INGOT_CAST) where input equals output and the corresponding CAST_METEORIC_IRON item does not exist

## Changes by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| shaedy180 | 26 | 6 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->