### PR TITLE
1.21.11 - Add rare platinum ore deposits to meteorite generation

### DIFF
--- a/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
+++ b/src/main/java/anya/pizza/houseki/world/structure/MeteoriteStructurePiece.java
@@ -283,7 +283,13 @@ public class MeteoriteStructurePiece extends StructurePiece {
                     if (noisyDist <= coreRadius) {
                         world.setBlockState(pos, ModBlocks.METEORIC_IRON.getDefaultState(), 2);
                     } else {
-                        world.setBlockState(pos, shellBlock, 2);
+                        // Rare platinum ore deposits carried within the meteorite shell.
+                        // ~5% of shell blocks are replaced with platinum ore.
+                        if (random.nextInt(20) == 0) {
+                            world.setBlockState(pos, getPlatinumOre(random), 2);
+                        } else {
+                            world.setBlockState(pos, shellBlock, 2);
+                        }
                     }
                 }
             }
@@ -305,6 +311,38 @@ public class MeteoriteStructurePiece extends StructurePiece {
             if (!chunkBox.contains(debrisPos)) continue;
             if (world.getBlockState(debrisPos).isAir()) {
                 world.setBlockState(debrisPos, ModBlocks.METEORIC_IRON.getDefaultState(), 2);
+            }
+        }
+
+        // Phase 4.5: Platinum ore deposits embedded in the crater walls and floor.
+        // Impact mineralization: 1-3 small clusters of 1-3 blocks each, placed
+        // below the crater floor surface so players must mine to find them.
+        int platinumClusterCount = 1 + random.nextInt(3);
+        for (int c = 0; c < platinumClusterCount; c++) {
+            double angle = random.nextDouble() * Math.PI * 2;
+            double dist = meteorRadius + random.nextDouble() * (craterRadius * 0.6);
+            int px = centerX + (int) Math.round(Math.cos(angle) * dist);
+            int pz = centerZ + (int) Math.round(Math.sin(angle) * dist);
+
+            double horizDist = Math.sqrt((px - centerX) * (px - centerX)
+                    + (pz - centerZ) * (pz - centerZ));
+            int floorY = getCraterFloorY(horizDist, craterRadius);
+            if (floorY >= surfaceY - 1) continue;
+
+            // Place cluster 2-4 blocks below the crater floor
+            int depth = 2 + random.nextInt(3);
+            int clusterSize = 1 + random.nextInt(3);
+            for (int b = 0; b < clusterSize; b++) {
+                int ox = (b == 0) ? 0 : random.nextInt(3) - 1;
+                int oy = (b == 0) ? 0 : random.nextInt(2);
+                int oz = (b == 0) ? 0 : random.nextInt(3) - 1;
+                BlockPos orePos = new BlockPos(px + ox, floorY - depth + oy, pz + oz);
+                if (!chunkBox.contains(orePos)) continue;
+                BlockState existing = world.getBlockState(orePos);
+                if (existing.isOf(Blocks.BEDROCK) || existing.isAir()) continue;
+                if (!meteorWontReplace(existing)) {
+                    world.setBlockState(orePos, getPlatinumOre(random), 2);
+                }
             }
         }
 
@@ -464,6 +502,14 @@ public class MeteoriteStructurePiece extends StructurePiece {
 
     private boolean meteorWontReplace(BlockState state) {
         return state.isIn(ModTags.Blocks.METEOR_WONT_REPLACE);
+    }
+
+    // Returns a random platinum ore variant: 70% regular, 30% deepslate.
+    private BlockState getPlatinumOre(Random random) {
+        if (random.nextInt(10) < 3) {
+            return ModBlocks.DEEPSLATE_PLATINUM_ORE.getDefaultState();
+        }
+        return ModBlocks.PLATINUM_ORE.getDefaultState();
     }
 
     private BlockState getFallenLogBlock(BiomeVariant variant) {


### PR DESCRIPTION
Platinum ore now spawns in two locations within meteor impact sites:

1. Meteorite shell: ~5% of outer shell blocks are replaced with platinum ore, representing extraterrestrial platinum carried within the asteroid.

2. Crater floor deposits: 1-3 small clusters of 1-3 platinum ore blocks are embedded 2-4 blocks below the crater floor surface, simulating impact-driven mineralization that players must mine to discover.

Ore variant is chosen randomly: 70% regular Platinum Ore, 30% Deepslate Platinum Ore. Respects the existing METEOR_WONT_REPLACE tag and bedrock protection.

How to change the probabilities (AI generated):
There are two separate values to tune, both in MeteoriteStructurePiece.java.

---

**1. How rare platinum ore spawns at all (shell + crater deposits)**

In Phase 3, this controls what fraction of shell blocks become platinum ore:

```java
if (random.nextInt(20) == 0) {
```

`nextInt(N)` returns 0 to N-1. It hits 0 exactly once in N rolls, so this is **1-in-20 = 5%**.

- `nextInt(10)` → 10% (more common)
- `nextInt(20)` → 5% (current)
- `nextInt(30)` → ~3.3% (rarer)
- `nextInt(50)` → 2% (very rare)

---

**2. Regular vs. Deepslate variant split**

In the `getPlatinumOre` helper method:

```java
if (random.nextInt(10) < 3) {
    return ModBlocks.DEEPSLATE_PLATINUM_ORE...  // 30%
}
return ModBlocks.PLATINUM_ORE...                // 70%
```

The threshold `< 3` out of 10 = 30% deepslate. Change the threshold to adjust:

- `< 1` → 10% deepslate / 90% regular
- `< 3` → 30% deepslate / 70% regular (current)
- `< 5` → 50/50
- `< 7` → 70% deepslate / 30% regular

Or use a different base number for finer control. For example 70% deepslate with a `nextInt(100)` roll:

```java
if (random.nextInt(100) < 70) {
    return ModBlocks.DEEPSLATE_PLATINUM_ORE...
}
return ModBlocks.PLATINUM_ORE...
```

---

The crater floor deposit count (Phase 4.5) is also tunable if you want more or fewer clusters:

```java
int platinumClusterCount = 1 + random.nextInt(3);  // 1-3 clusters
int clusterSize = 1 + random.nextInt(3);             // 1-3 blocks per cluster
```

Raise the `nextInt` argument to increase the upper bound.